### PR TITLE
Change the meaning of hooks with no command name.

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -231,7 +231,22 @@ class AnnotatedCommand extends Command
         return $args;
     }
 
+    /**
+     * Returns all of the hook names that may be called for this command.
+     *
+     * @return array
+     */
     protected function getNames()
+    {
+        return array_filter(
+            array_merge(
+                $this->getNamesUsingCommands(),
+                [HookManager::getClassNameFromCallback($this->commandCallback)]
+            )
+        );
+    }
+
+    protected function getNamesUsingCommands()
     {
         return array_merge(
             [$this->getName()],

--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -141,13 +141,12 @@ class AnnotatedCommandFactory
      *
      *   @hook type name type
      *
-     * For example, the pre-validate hook for the core-init command is:
+     * For example, the pre-validate hook for the core:init command is:
      *
-     *   @hook pre-validate core-init
+     *   @hook pre-validate core:init
      *
-     * If no command name is provided, then we will presume
-     * that the name of this method is the same as the name
-     * of the command being hooked (in a different commandFile).
+     * If no command name is provided, then this hook will affect every
+     * command that is defined in the same file.
      *
      * If no hook is provided, then we will presume that ALTER_RESULT
      * is intended.
@@ -163,14 +162,14 @@ class AnnotatedCommandFactory
         }
         $hookData = $commandInfo->getAnnotation('hook');
         $hook = $this->getNthWord($hookData, 0, HookManager::ALTER_RESULT);
-        $commandName = $this->getNthWord($hookData, 1, $commandInfo->getName());
+        $commandName = $this->getNthWord($hookData, 1);
 
         // Register the hook
         $callback = [$commandFileInstance, $commandInfo->getMethodName()];
         $this->commandProcessor()->hookManager()->add($callback, $hook, $commandName);
     }
 
-    protected function getNthWord($string, $n, $default, $delimiter = ' ')
+    protected function getNthWord($string, $n, $default = '', $delimiter = ' ')
     {
         $words = explode($delimiter, $string);
         if (!empty($words[$n])) {

--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -23,12 +23,12 @@ class HookManager implements EventSubscriberInterface
     const PRE_INTERACT = 'pre-interact';
     const INTERACT = 'interact';
     const POST_INTERACT = 'post-interact';
-    const PRE_COMMAND_EVENT = 'pre-command';
-    const COMMAND_EVENT = 'command';
-    const POST_COMMAND_EVENT = 'post-command';
     const PRE_ARGUMENT_VALIDATOR = 'pre-validate';
     const ARGUMENT_VALIDATOR = 'validate';
     const POST_ARGUMENT_VALIDATOR = 'post-validate';
+    const PRE_COMMAND_EVENT = 'pre-command';
+    const COMMAND_EVENT = 'command';
+    const POST_COMMAND_EVENT = 'post-command';
     const PRE_PROCESS_RESULT = 'pre-process';
     const PROCESS_RESULT = 'process';
     const POST_PROCESS_RESULT = 'post-process';
@@ -42,6 +42,11 @@ class HookManager implements EventSubscriberInterface
     {
     }
 
+    public function getAllHooks()
+    {
+        return $this->hooks;
+    }
+
     /**
      * Add a hook
      *
@@ -52,7 +57,26 @@ class HookManager implements EventSubscriberInterface
      */
     public function add(callable $callback, $hook, $name = '*')
     {
+        if (empty($name)) {
+            $name = static::getClassNameFromCallback($callback);
+        }
         $this->hooks[$name][$hook][] = $callback;
+    }
+
+    /**
+     * If a command hook does not specify any particular command
+     * name that it should be attached to, then it will be applied
+     * to every command that is defined in the same class as the hook.
+     * This is controlled by using the namespace + class name of
+     * the implementing class of the callback hook.
+     */
+    public static function getClassNameFromCallback($callback)
+    {
+        if (!is_array($callback)) {
+            return '';
+        }
+        $reflectionClass = new \ReflectionClass($callback[0]);
+        return $reflectionClass->getName();
     }
 
     /**

--- a/tests/src/ExampleHookAllCommandFile.php
+++ b/tests/src/ExampleHookAllCommandFile.php
@@ -1,0 +1,41 @@
+<?php
+namespace Consolidation\TestUtils;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Consolidation\AnnotatedCommand\CommandError;
+use Consolidation\AnnotatedCommand\AnnotationData;
+
+/**
+ *
+ */
+class ExampleHookAllCommandFile
+{
+    public function doCat($one, $two = '', $options = ['flip' => false])
+    {
+        if ($options['flip']) {
+            return "{$two}{$one}";
+        }
+        return "{$one}{$two}";
+    }
+
+    public function doRepeat($one, $two = '', $options = ['repeat' => 1])
+    {
+        return str_repeat("{$one}{$two}", $options['repeat']);
+    }
+
+    /**
+     * This hook function does not specify which command or annotation
+     * it is hooking; that makes it apply to every command in the same class.
+     *
+     * @hook alter
+     */
+    public function alterAllCommands($result)
+    {
+        if (is_string($result)) {
+            $result = "*** $result ***";
+        }
+        return $result;
+    }
+}

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -220,6 +220,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('alter test:hook', $hookInfo->getAnnotation('hook'));
 
         $commandFactory->registerCommandHook($hookInfo, $commandFileInstance);
+
         $hookCallback = $commandFactory->hookManager()->get('test:hook', 'alter');
         $this->assertTrue($hookCallback != null);
         $this->assertEquals(1, count($hookCallback));
@@ -235,6 +236,35 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
 
         $input = new StringInput('test:hook bar');
         $this->assertRunCommandViaApplicationEquals($command, $input, '<[bar]>');
+    }
+
+    function testHookAllCommands()
+    {
+        $commandFileInstance = new \Consolidation\TestUtils\ExampleHookAllCommandFile();
+        $commandFactory = new AnnotatedCommandFactory();
+
+        $hookInfo = $commandFactory->createCommandInfo($commandFileInstance, 'alterAllCommands');
+
+        $this->assertTrue($hookInfo->hasAnnotation('hook'));
+        $this->assertEquals('alter', $hookInfo->getAnnotation('hook'));
+
+        $commandFactory->registerCommandHook($hookInfo, $commandFileInstance);
+
+        $hookCallback = $commandFactory->hookManager()->get('Consolidation\TestUtils\ExampleHookAllCommandFile', 'alter');
+        $this->assertTrue($hookCallback != null);
+        $this->assertEquals(1, count($hookCallback));
+        $this->assertEquals(2, count($hookCallback[0]));
+        $this->assertTrue(is_callable($hookCallback[0]));
+        $this->assertEquals('alterAllCommands', $hookCallback[0][1]);
+
+        $commandInfo = $commandFactory->createCommandInfo($commandFileInstance, 'doCat');
+        $command = $commandFactory->createCommand($commandInfo, $commandFileInstance);
+
+        $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
+        $this->assertEquals('do:cat', $command->getName());
+
+        $input = new StringInput('do:cat bar');
+        $this->assertRunCommandViaApplicationEquals($command, $input, '*** bar ***');
     }
 
     function testAnnotatedHookedCommand()

--- a/tests/testCommandFileDiscovery.php
+++ b/tests/testCommandFileDiscovery.php
@@ -20,15 +20,17 @@ class CommandFileDiscoveryTests extends \PHPUnit_Framework_TestCase
         // find were all found.  We don't find anything in
         // 'beta' because only 'alpha' is in the search path.
         $this->assertContains('./src/ExampleCommandFile.php', $commandFilePaths);
+        $this->assertContains('./src/ExampleHookAllCommandFile.php', $commandFilePaths);
         $this->assertContains('./src/alpha/AlphaCommandFile.php', $commandFilePaths);
         $this->assertContains('./src/alpha/Inclusive/IncludedCommandFile.php', $commandFilePaths);
 
         // Make sure that there are no additional items found.
-        $this->assertEquals(3, count($commandFilePaths));
+        $this->assertEquals(4, count($commandFilePaths));
 
         // Ensure that the command file namespaces that we expected
         // to be generated all match.
         $this->assertContains('\Consolidation\TestUtils\ExampleCommandFile', $commandFileNamespaces);
+        $this->assertContains('\Consolidation\TestUtils\ExampleHookAllCommandFile', $commandFileNamespaces);
         $this->assertContains('\Consolidation\TestUtils\alpha\AlphaCommandFile', $commandFileNamespaces);
         $this->assertContains('\Consolidation\TestUtils\alpha\Inclusive\IncludedCommandFile', $commandFileNamespaces);
 
@@ -59,15 +61,17 @@ class CommandFileDiscoveryTests extends \PHPUnit_Framework_TestCase
         // depth is only 2, which excludes directories that are
         // three levels deep.
         $this->assertContains('./src/ExampleCommandFile.php', $commandFilePaths);
+        $this->assertContains('./src/ExampleHookAllCommandFile.php', $commandFilePaths);
         $this->assertContains('./src/alpha/AlphaCommandFile.php', $commandFilePaths);
         $this->assertContains('./src/beta/BetaCommandFile.php', $commandFilePaths);
 
         // Make sure that there are no additional items found.
-        $this->assertEquals(3, count($commandFilePaths));
+        $this->assertEquals(4, count($commandFilePaths));
 
         // Ensure that the command file namespaces that we expected
         // to be generated all match.
         $this->assertContains('\Consolidation\TestUtils\ExampleCommandFile', $commandFileNamespaces);
+        $this->assertContains('\Consolidation\TestUtils\ExampleHookAllCommandFile', $commandFileNamespaces);
         $this->assertContains('\Consolidation\TestUtils\alpha\AlphaCommandFile', $commandFileNamespaces);
         $this->assertContains('\Consolidation\TestUtils\beta\BetaCommandFile', $commandFileNamespaces);
 


### PR DESCRIPTION
Hooks with no command name are those in the form:
```
@hook alter
```
Instead of:
```
@hook alter my:command
```
These now apply to all commands defined in the same class, rather than to some command elsewhere that happens to have the same method name.

Hooks with no command name are probably rare-to-nonexistent.  All the same, this is being treated as a breaking change.