### PR TITLE
Provide @command name to hooks

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -99,7 +99,7 @@ class AnnotatedCommand extends Command
         $this->setDescription($commandInfo->getDescription());
         $this->setHelp($commandInfo->getHelp());
         $this->setAliases($commandInfo->getAliases());
-        $this->setAnnotationData($commandInfo->getAnnotations());
+        $this->setAnnotationData($commandInfo->getAnnotationsForCommand());
         foreach ($commandInfo->getExampleUsages() as $usage => $description) {
             // Symfony Console does not support attaching a description to a usage
             $this->addUsage($usage);

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -9,6 +9,10 @@ use Consolidation\AnnotatedCommand\AnnotationData;
  * Given a class and method name, parse the annotations in the
  * DocBlock comment, and provide accessor methods for all of
  * the elements that are needed to create a Symfony Console Command.
+ *
+ * Note that the name of this class is now somewhat of a misnomer,
+ * as we now use it to hold annotation data for hooks as well as commands.
+ * It would probably be better to rename this to MethodInfo at some point.
  */
 class CommandInfo
 {
@@ -155,6 +159,26 @@ class CommandInfo
     {
         $this->parseDocBlock();
         return $this->otherAnnotations;
+    }
+
+    /**
+     * Get any annotations included in the docblock comment,
+     * also including default values such as @command.  We add
+     * in the default @command annotation late, and only in a
+     * copy of the annotation data because we use the existance
+     * of a @command to indicate that this CommandInfo is
+     * a command, and not a hook or anything else.
+     *
+     * @return AnnotationData
+     */
+    public function getAnnotationsForCommand()
+    {
+        return new AnnotationData(
+            $this->getAnnotations()->getArrayCopy() +
+            [
+                'command' => $this->getName(),
+            ]
+        );
     }
 
     /**

--- a/src/Parser/Internal/AbstractCommandDocBlockParser.php
+++ b/src/Parser/Internal/AbstractCommandDocBlockParser.php
@@ -78,10 +78,11 @@ abstract class AbstractCommandDocBlockParser
      */
     protected function processCommandTag($tag)
     {
-        $this->commandInfo->setName($this->getTagContents($tag));
+        $commandName = $this->getTagContents($tag);
+        $this->commandInfo->setName($commandName);
         // We also store the name in the 'other annotations' so that is is
         // possible to determine if the method had a @command annotation.
-        $this->processGenericTag($tag);
+        $this->commandInfo->addOtherAnnotation($tag->getName(), $commandName);
     }
 
     /**

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -45,6 +45,9 @@ class ExampleCommandFile
         return "{$one}{$two}";
     }
 
+    /**
+     * @command my:repeat
+     */
     public function myRepeat($one, $two = '', $options = ['repeat' => 1])
     {
         return str_repeat("{$one}{$two}", $options['repeat']);
@@ -101,12 +104,14 @@ class ExampleCommandFile
      * This command will add one and two. If the --negate flag
      * is provided, then the result is negated.
      *
+     * @command test:arithmatic
      * @param integer $one The first number to add.
      * @param integer $two The other number to add.
      * @option $negate Whether or not the result should be negated.
      * @aliases arithmatic
      * @usage 2 2 --negate
      *   Add two plus two and then negate.
+     * @custom
      */
     public function testArithmatic($one, $two, $options = ['negate' => false])
     {
@@ -184,6 +189,39 @@ class ExampleCommandFile
         $before = $annotationData->get('before', '-');
         $after = $annotationData->get('after', '-');
         return "$before$result$after";
+    }
+
+    /**
+     * Alter the results of the hook with its command name.
+     *
+     * @hook alter @addmycommandname
+     */
+    public function hookAddCommandName($result, $args, AnnotationData $annotationData)
+    {
+        return "$result from " . $annotationData['command'];
+    }
+
+    /**
+     * Here is a hook with an explicit command annotation that we will alter
+     * with the preceeding hook
+     *
+     * @command alter-me
+     * @addmycommandname
+     */
+    public function alterMe()
+    {
+        return "splendiferous";
+    }
+
+    /**
+     * Here is another hook that has no command annotation that should be
+     * altered with the default value for the command name
+     *
+     * @addmycommandname
+     */
+    public function alterMeToo()
+    {
+        return "fantabulous";
     }
 
     public function testHello($who)


### PR DESCRIPTION
Ensure that @command annotation with command name is always available in annotated data provided to hooks.