### PR TITLE
Hook options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,16 @@ Extant commandline tools that utilize this technique include:
 
 This library provides routines to produce the Symfony\Component\Console\Command\Command from all public methods defined in the provided class.
 
-**Note** If you are looking for a very fast way to write a Symfony Console-base command-line tool, you should consider using [Robo](https://github.com/consolidation/Robo), which is built on top of this library, and adds additional conveniences to get you going quickly. See [Using Robo as a Framework](https://github.com/consolidation/Robo/docs/framework.md).  It is possible to use this project without Robo if desired, though.
+**Note** If you are looking for a very fast way to write a Symfony Console-base command-line tool, you should consider using [Robo](https://github.com/consolidation/Robo), which is built on top of this library, and adds additional conveniences to get you going quickly. See [Using Robo as a Framework](https://github.com/consolidation/Robo/docs/framework.md).  It is possible to use this project without Robo if desired, of course.
 
 ## Library Usage
 
 This is a library intended to be used in some other project.  Require from your composer.json file:
 ```
     "require": {
-        "consolidation/annotated-command": "~1|~2"
+        "consolidation/annotated-command": "~2"
     },
 ```
-In the 2.x branch, the interfaces ValidatorInterface, ProcessResultInterface and AlterResultInterface changed. If your application uses any of these interfaces, then you should require version "~2" instead. The 2.x branch is compatible with the 1.x branch in other respects.
 
 ## Example Annotated Command Class
 The public methods of the command class define its commands, and the parameters of each method define its arguments and options. The command options, if any, are declared as the last parameter of the methods. The options will be passed in as an associative array; the default options of the last parameter should list the options recognized by the command.
@@ -75,6 +74,7 @@ If an annotation is given instead, then this hook function will run for all comm
 There are nine types of hooks supported:
 
 - Command Event (Symfony)
+- Option
 - Initialize (Symfony)
 - Interact (Symfony)
 - Validate
@@ -89,6 +89,10 @@ Most of these also have "pre" and "post" varieties, to give more flexibility vis
 ### Command Event Hook
 
 The command-event hook is called via the Symfony Console command event notification callback mechanism. This happens prior to event dispatching and command / option validation.  Note that Symfony does not allow the $input object to be altered in this hook; any change made here will be reset before the interact hook is called.
+
+### Option Event Hook
+
+The option event hook is called for a specific command, whenever it is executed, or its help command is called. Any additional options for the command may be added here by instantiating and returnng an InputOption array.
 
 ### Initialize Hook
 

--- a/src/AlterOptionsCommandEvent.php
+++ b/src/AlterOptionsCommandEvent.php
@@ -1,0 +1,84 @@
+<?php
+namespace Consolidation\AnnotatedCommand;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use Consolidation\AnnotatedCommand\ExitCodeInterface;
+use Consolidation\AnnotatedCommand\OutputDataInterface;
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
+
+/**
+ * AlterOptionsCommandEvent is a subscriber to the Command Event
+ * that looks up any additional options (e.g. from an OPTION_HOOK)
+ * that should be added to the command.  Options need to be added
+ * in two circumstances:
+ *
+ * 1. When 'help' for the command is called, so that the additional
+ *    command options may be listed in the command description.
+ *
+ * 2. When the command itself is called, so that option validation
+ *    may be done.
+ *
+ * We defer the addition of options until these times so that we
+ * do not invoke the option hooks for every command on every run
+ * of the program, and so that we do not need to defer the addition
+ * of all of the application hooks until after all of the application
+ * commands have been added. (Hooks may appear in the same command files
+ * as command implementations; applications may support command file
+ * plug-ins, and hooks may add options to commands defined in other
+ * commandfiles.)
+ */
+class AlterOptionsCommandEvent implements EventSubscriberInterface
+{
+    /** var Application */
+    protected $application;
+
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    /**
+     * @param ConsoleCommandEvent $event
+     */
+    public function alterCommandOptions(ConsoleCommandEvent $event)
+    {
+        /* @var Command $command */
+        $command = $event->getCommand();
+        $names = [$command->getName()];
+        if ($command->getName() == 'help') {
+            $nameOfCommandToDescribe = $event->getInput()->getArgument('command_name');
+            $commandToDescribe = $this->application->find($nameOfCommandToDescribe);
+            $this->findAndAddHookOptions($commandToDescribe);
+        }
+        else {
+            $this->findAndAddHookOptions($command);
+        }
+    }
+
+    public function findAndAddHookOptions($command)
+    {
+        if (!$command instanceof AnnotatedCommand) {
+            return;
+        }
+        $inputOptions = $command->optionsHook();
+        $command->addOptions($inputOptions);
+    }
+
+
+    /**
+     * @{@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [ConsoleEvents::COMMAND => 'alterCommandOptions'];
+    }
+}

--- a/src/AlterOptionsCommandEvent.php
+++ b/src/AlterOptionsCommandEvent.php
@@ -69,8 +69,7 @@ class AlterOptionsCommandEvent implements EventSubscriberInterface
         if (!$command instanceof AnnotatedCommand) {
             return;
         }
-        $inputOptions = $command->optionsHook();
-        $command->addOptions($inputOptions);
+        $command->optionsHook();
     }
 
 

--- a/src/AlterOptionsCommandEvent.php
+++ b/src/AlterOptionsCommandEvent.php
@@ -53,7 +53,6 @@ class AlterOptionsCommandEvent implements EventSubscriberInterface
     {
         /* @var Command $command */
         $command = $event->getCommand();
-        $names = [$command->getName()];
         if ($command->getName() == 'help') {
             $nameOfCommandToDescribe = $event->getInput()->getArgument('command_name');
             $commandToDescribe = $this->application->find($nameOfCommandToDescribe);

--- a/src/AlterOptionsCommandEvent.php
+++ b/src/AlterOptionsCommandEvent.php
@@ -58,8 +58,7 @@ class AlterOptionsCommandEvent implements EventSubscriberInterface
             $nameOfCommandToDescribe = $event->getInput()->getArgument('command_name');
             $commandToDescribe = $this->application->find($nameOfCommandToDescribe);
             $this->findAndAddHookOptions($commandToDescribe);
-        }
-        else {
+        } else {
             $this->findAndAddHookOptions($command);
         }
     }

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -213,7 +213,6 @@ class AnnotatedCommand extends Command
         }
         if (!$mode) {
             $mode = InputOption::VALUE_NONE;
-            $default = null;
         }
 
         $inputOption = new InputOption(

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -303,20 +303,7 @@ class AnnotatedCommand extends Command
      */
     protected function getNames()
     {
-        return array_filter(
-            array_merge(
-                $this->getNamesUsingCommands(),
-                [HookManager::getClassNameFromCallback($this->commandCallback)]
-            )
-        );
-    }
-
-    protected function getNamesUsingCommands()
-    {
-        return array_merge(
-            [$this->getName()],
-            $this->getAliases()
-        );
+        return HookManager::getNames($this, $this->commandCallback);
     }
 
     /**

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -188,39 +188,42 @@ class AnnotatedCommand extends Command
     protected function addOptions($inputOptions, $automaticOptions)
     {
         foreach ($inputOptions as $name => $inputOption) {
-            $default = $inputOption->getDefault();
             $description = $inputOption->getDescription();
 
             if (empty($description) && isset($automaticOptions[$name])) {
                 $description = $automaticOptions[$name]->getDescription();
+                $inputOption = static::inputOptionSetDescription($inputOption, $description);
             }
-
-            // Recover the 'mode' value, because Symfony is stubborn
-            $mode = 0;
-            if ($inputOption->isValueRequired()) {
-                $mode |= InputOption::VALUE_REQUIRED;
-            }
-            if ($inputOption->isValueOptional()) {
-                $mode |= InputOption::VALUE_OPTIONAL;
-            }
-            if ($inputOption->isArray()) {
-                $mode |= InputOption::VALUE_IS_ARRAY;
-            }
-            if (!$mode) {
-                $mode = InputOption::VALUE_NONE;
-                $default = null;
-            }
-
-            // Add the option; note that Symfony doesn't have a convenient
-            // method to do this that takes an InputOption
-            $this->addOption(
-                $inputOption->getName(),
-                $inputOption->getShortcut(),
-                $mode,
-                $description,
-                $default
-            );
+            $this->getDefinition()->addOption($inputOption);
         }
+    }
+
+    protected static function inputOptionSetDescription($inputOption, $description)
+    {
+        // Recover the 'mode' value, because Symfony is stubborn
+        $mode = 0;
+        if ($inputOption->isValueRequired()) {
+            $mode |= InputOption::VALUE_REQUIRED;
+        }
+        if ($inputOption->isValueOptional()) {
+            $mode |= InputOption::VALUE_OPTIONAL;
+        }
+        if ($inputOption->isArray()) {
+            $mode |= InputOption::VALUE_IS_ARRAY;
+        }
+        if (!$mode) {
+            $mode = InputOption::VALUE_NONE;
+            $default = null;
+        }
+
+        $inputOption = new InputOption(
+            $inputOption->getName(),
+            $inputOption->getShortcut(),
+            $mode,
+            $description,
+            $inputOption->getDefault()
+        );
+        return $inputOption;
     }
 
     /**

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -185,7 +185,7 @@ class AnnotatedCommand extends Command
         $this->addOptions($inputOptions + $automaticOptions, $automaticOptions);
     }
 
-    protected function addOptions($inputOptions, $automaticOptions)
+    public function addOptions($inputOptions, $automaticOptions = [])
     {
         foreach ($inputOptions as $name => $inputOption) {
             $description = $inputOption->getDescription();
@@ -274,6 +274,20 @@ class AnnotatedCommand extends Command
     protected function getNames()
     {
         return HookManager::getNames($this, $this->commandCallback);
+    }
+
+    /**
+     * Add any options to this command that are defined by hook implementations
+     *
+     * @return InputOption[]
+     */
+    public function optionsHook()
+    {
+        return $this->commandProcessor()->optionsHook(
+            $this,
+            $this->getNames(),
+            $this->annotationData
+        );
     }
 
     /**

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -278,16 +278,27 @@ class AnnotatedCommand extends Command
 
     /**
      * Add any options to this command that are defined by hook implementations
-     *
-     * @return InputOption[]
      */
     public function optionsHook()
     {
-        return $this->commandProcessor()->optionsHook(
+        $this->commandProcessor()->optionsHook(
             $this,
             $this->getNames(),
             $this->annotationData
         );
+    }
+
+    public function optionsHookForHookAnnotations($commandInfoList)
+    {
+        foreach ($commandInfoList as $commandInfo) {
+            $inputOptions = $commandInfo->inputOptions();
+            $this->addOptions($inputOptions);
+            foreach ($commandInfo->getExampleUsages() as $usage => $description) {
+                if (!in_array($usage, $this->getUsages())) {
+                    $this->addUsage($usage);
+                }
+            }
+        }
     }
 
     /**

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -180,9 +180,9 @@ class AnnotatedCommand extends Command
 
     public function setCommandOptions($commandInfo, $automaticOptions = [])
     {
-        $explicitOptions = $this->explicitOptions($commandInfo);
+        $inputOptions = $commandInfo->inputOptions();
 
-        $this->addOptions($explicitOptions + $automaticOptions, $automaticOptions);
+        $this->addOptions($inputOptions + $automaticOptions, $automaticOptions);
     }
 
     protected function addOptions($inputOptions, $automaticOptions)
@@ -224,39 +224,6 @@ class AnnotatedCommand extends Command
             $inputOption->getDefault()
         );
         return $inputOption;
-    }
-
-    /**
-     * Get the options that are explicitly defined, e.g. via
-     * @option annotations, or via $options = ['someoption' => 'defaultvalue']
-     * in the command method parameter list.
-     *
-     * @return InputOption[]
-     */
-    protected function explicitOptions($commandInfo)
-    {
-        $explicitOptions = [];
-
-        $opts = $commandInfo->options()->getValues();
-        foreach ($opts as $name => $defaultValue) {
-            $description = $commandInfo->options()->getDescription($name);
-
-            $fullName = $name;
-            $shortcut = '';
-            if (strpos($name, '|')) {
-                list($fullName, $shortcut) = explode('|', $name, 2);
-            }
-
-            if (is_bool($defaultValue)) {
-                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_NONE, $description);
-            } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {
-                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description);
-            } else {
-                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_OPTIONAL, $description, $defaultValue);
-            }
-        }
-
-        return $explicitOptions;
     }
 
     protected function getArgsWithPassThrough($input)

--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -222,6 +222,13 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         // Register the hook
         $callback = [$commandFileInstance, $commandInfo->getMethodName()];
         $this->commandProcessor()->hookManager()->add($callback, $hook, $commandName);
+
+        // If the hook has options, then also register the commandInfo
+        // with the hook manager, so that we can add options and such to
+        // the commands they hook.
+        if (!$commandInfo->options()->empty()) {
+            $this->commandProcessor()->hookManager()->recordHookOptions($commandInfo, $commandName);
+        }
     }
 
     protected function getNthWord($string, $n, $default = '', $delimiter = ' ')

--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -226,7 +226,7 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         // If the hook has options, then also register the commandInfo
         // with the hook manager, so that we can add options and such to
         // the commands they hook.
-        if (!$commandInfo->options()->empty()) {
+        if (!$commandInfo->options()->isEmpty()) {
             $this->commandProcessor()->hookManager()->recordHookOptions($commandInfo, $commandName);
         }
     }

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -66,6 +66,14 @@ class CommandProcessor
         return $this->hookManager()->initializeHook($input, $names, $annotationData);
     }
 
+    public function optionsHook(
+        AnnotatedCommand $command,
+        $names,
+        AnnotationData $annotationData
+    ) {
+        return $this->hookManager()->optionsHook($command, $names, $annotationData);
+    }
+
     public function interact(
         InputInterface $input,
         OutputInterface $output,

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -71,7 +71,7 @@ class CommandProcessor
         $names,
         AnnotationData $annotationData
     ) {
-        return $this->hookManager()->optionsHook($command, $names, $annotationData);
+        $this->hookManager()->optionsHook($command, $names, $annotationData);
     }
 
     public function interact(

--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -69,6 +69,24 @@ class HookManager implements EventSubscriberInterface
         $this->hooks[$name][$hook][] = $callback;
     }
 
+    public static function getNames($command, $callback)
+    {
+        return array_filter(
+            array_merge(
+                static::getNamesUsingCommands($command),
+                [static::getClassNameFromCallback($callback)]
+            )
+        );
+    }
+
+    protected static function getNamesUsingCommands($command)
+    {
+        return array_merge(
+            [$command->getName()],
+            $command->getAliases()
+        );
+    }
+
     /**
      * If a command hook does not specify any particular command
      * name that it should be attached to, then it will be applied
@@ -76,7 +94,7 @@ class HookManager implements EventSubscriberInterface
      * This is controlled by using the namespace + class name of
      * the implementing class of the callback hook.
      */
-    public static function getClassNameFromCallback($callback)
+    protected static function getClassNameFromCallback($callback)
     {
         if (!is_array($callback)) {
             return '';

--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -281,32 +281,12 @@ class HookManager implements EventSubscriberInterface
         $names,
         AnnotationData $annotationData
     ) {
-        $inputOptions = [];
         $optionHooks = $this->getOptionHooks($names, $annotationData);
         foreach ($optionHooks as $optionHook) {
-            $inputOptions = array_merge(
-                $this->callOptionHook($optionHook, $command, $annotationData),
-                $inputOptions
-            );
+            $this->callOptionHook($optionHook, $command, $annotationData);
         }
-        return array_merge($inputOptions, $this->getHookInputOptions($command));
-    }
-
-    // TODO: cache any CommandInfo object that is a hook and defines
-    // options.  Here, find any CommandInfo object that hooks this command.
-    // Git its input options.
-    protected function getHookInputOptions($command)
-    {
-        $inputOptions = [];
-        // find all hook options for $command.
         $commandInfoList = $this->getHookOptionsForCommand($command);
-        foreach ($commandInfoList as $commandInfo) {
-            $inputOptions = array_merge(
-                $inputOptions = $commandInfo->inputOptions(),
-                $inputOptions
-            );
-        }
-        return $inputOptions;
+        $command->optionsHookForHookAnnotations($commandInfoList);
     }
 
     protected function getHookOptionsForCommand($command)
@@ -621,8 +601,7 @@ class HookManager implements EventSubscriberInterface
         if (!$command instanceof \Consolidation\AnnotatedCommand\AnnotatedCommand) {
             return;
         }
-        $commandInfoList = $command->optionsHook();
-        $command->addOptions($inputOptions);
+        $command->optionsHook();
     }
 
     /**

--- a/src/Hooks/OptionHookInterface.php
+++ b/src/Hooks/OptionHookInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Hooks;
+
+/**
+ * Add options to a command.
+ *
+ * @see HookManager::addOptionHook()
+ */
+interface OptionHookInterface
+{
+    public function getOptions($command, $annotationData);
+}

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -1,6 +1,7 @@
 <?php
 namespace Consolidation\AnnotatedCommand\Parser;
 
+use Symfony\Component\Console\Input\InputOption;
 use Consolidation\AnnotatedCommand\Parser\Internal\CommandDocBlockParser;
 use Consolidation\AnnotatedCommand\Parser\Internal\CommandDocBlockParserFactory;
 use Consolidation\AnnotatedCommand\AnnotationData;
@@ -340,6 +341,40 @@ class CommandInfo
     public function optionParamName()
     {
         return $this->optionParamName;
+    }
+
+    /**
+     * Get the inputOptions for the options associated with this CommandInfo
+     * object, e.g. via @option annotations, or from
+     * $options = ['someoption' => 'defaultvalue'] in the command method
+     * parameter list.
+     *
+     * @return InputOption[]
+     */
+    public function inputOptions()
+    {
+        $explicitOptions = [];
+
+        $opts = $this->options()->getValues();
+        foreach ($opts as $name => $defaultValue) {
+            $description = $this->options()->getDescription($name);
+
+            $fullName = $name;
+            $shortcut = '';
+            if (strpos($name, '|')) {
+                list($fullName, $shortcut) = explode('|', $name, 2);
+            }
+
+            if (is_bool($defaultValue)) {
+                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_NONE, $description);
+            } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {
+                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description);
+            } else {
+                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_OPTIONAL, $description, $defaultValue);
+            }
+        }
+
+        return $explicitOptions;
     }
 
 

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -377,7 +377,6 @@ class CommandInfo
         return $explicitOptions;
     }
 
-
     /**
      * An option might have a name such as 'silent|s'. In this
      * instance, we will allow the @option or @default tag to

--- a/src/Parser/DefaultsWithDescriptions.php
+++ b/src/Parser/DefaultsWithDescriptions.php
@@ -48,6 +48,16 @@ class DefaultsWithDescriptions
     }
 
     /**
+     * Return true if this set of options is empty
+     *
+     * @return
+     */
+    public function empty()
+    {
+        return empty($this->values);
+    }
+
+    /**
      * Check to see whether the speicifed key exists in the collection.
      *
      * @param string $key

--- a/src/Parser/DefaultsWithDescriptions.php
+++ b/src/Parser/DefaultsWithDescriptions.php
@@ -52,7 +52,7 @@ class DefaultsWithDescriptions
      *
      * @return
      */
-    public function empty()
+    public function isEmpty()
     {
         return empty($this->values);
     }

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -75,10 +75,10 @@ class AlphaCommandFile
      *   first: I
      *   second: II
      *   third: III
-     * @usage try:formatters --format=yaml
-     * @usage try:formatters --format=csv
-     * @usage try:formatters --fields=first,third
-     * @usage try:formatters --fields=III,II
+     * @usage example:table --format=yaml
+     * @usage example:table --format=csv
+     * @usage example:table --fields=first,third
+     * @usage example:table --fields=III,II
      * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
      */
     public function exampleTable($options = ['format' => 'table', 'fields' => ''])
@@ -97,14 +97,12 @@ class AlphaCommandFile
      */
     public function additionalOptionForExampleTable($command, $annotationData)
     {
-        $dynamicOption = new InputOption(
+        $command->addOption(
             'dynamic',
             '',
             InputOption::VALUE_NONE,
             'Option added by @hook option example:table'
         );
-
-        return [ $dynamicOption ];
     }
 
     /**
@@ -112,6 +110,7 @@ class AlphaCommandFile
      *
      * @hook alter example:table
      * @option $french Add a row with French numbers.
+     * @usage example:table --french
      */
     public function alterFormatters($result, array $args, AnnotationData $annotationData)
     {

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -4,6 +4,8 @@ namespace Consolidation\TestUtils\alpha;
 use Consolidation\AnnotatedCommand\CommandError;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\AssociativeList;
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Test file used in the testCommandDiscovery() test.
@@ -88,6 +90,36 @@ class AlphaCommandFile
             [ 'first' => 'Uno',  'second' => 'Dos',  'third' => 'Tres'  ],
         ];
         return new RowsOfFields($outputData);
+    }
+
+    /**
+     * @hook option example:table
+     */
+    public function additionalOptionForExampleTable($command, $annotationData)
+    {
+        $dynamicOption = new InputOption(
+            'dynamic',
+            '',
+            InputOption::VALUE_NONE,
+            'Option added by @hook option example:table'
+        );
+
+        return [ $dynamicOption ];
+    }
+
+    /**
+     * Demonstrate an alter hook with an option
+     *
+     * @hook alter example:table
+     * @option $french Add a row with French numbers.
+     */
+    public function alterFormatters($result, array $args, AnnotationData $annotationData)
+    {
+        if ($args['options']['french']) {
+            $result[] = [ 'first' => 'Un',  'second' => 'Deux',  'third' => 'Trois'  ];
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -595,9 +595,11 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         }
 
         $application = new Application('TestApplication', '0.0.0');
+        $alterOptionsEventManager = new AlterOptionsCommandEvent($application);
 
         $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
         $eventDispatcher->addSubscriber($this->commandFactory->commandProcessor()->hookManager());
+        $eventDispatcher->addSubscriber($alterOptionsEventManager);
         $application->setDispatcher($eventDispatcher);
 
         $application->setAutoExit(false);

--- a/tests/testFullStack.php
+++ b/tests/testFullStack.php
@@ -27,8 +27,17 @@ use Consolidation\OutputFormatters\FormatterManager;
  */
 class FullStackTests extends \PHPUnit_Framework_TestCase
 {
+    protected $application;
+    protected $commandFactory;
+
     function setup() {
         $this->application = new Application('TestApplication', '0.0.0');
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $alterOptionsEventManager = new AlterOptionsCommandEvent($this->application);
+        $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+        $eventDispatcher->addSubscriber($this->commandFactory->commandProcessor()->hookManager());
+        $eventDispatcher->addSubscriber($alterOptionsEventManager);
+        $this->application->setDispatcher($eventDispatcher);
         $this->application->setAutoExit(false);
     }
 
@@ -43,12 +52,11 @@ class FullStackTests extends \PHPUnit_Framework_TestCase
     function testAutomaticOptions()
     {
         $commandFileInstance = new \Consolidation\TestUtils\alpha\AlphaCommandFile;
-        $commandFactory = new AnnotatedCommandFactory();
         $formatter = new FormatterManager();
-        $commandFactory->commandProcessor()->setFormatterManager($formatter);
-        $commandInfo = $commandFactory->createCommandInfo($commandFileInstance, 'exampleTable');
+        $this->commandFactory->commandProcessor()->setFormatterManager($formatter);
+        $commandInfo = $this->commandFactory->createCommandInfo($commandFileInstance, 'exampleTable');
 
-        $command = $commandFactory->createCommand($commandInfo, $commandFileInstance);
+        $command = $this->commandFactory->createCommand($commandInfo, $commandFileInstance);
         $this->application->add($command);
 
         $containsList =
@@ -158,6 +166,22 @@ EOT;
         // When --field is specified (instead of --fields), then the format
         // is forced to 'string'.
         $this->assertRunCommandViaApplicationEquals('example:table --field=II', $expectedSingleField);
+
+        // Check the help for the example table command
+        $this->assertRunCommandViaApplicationContains('help example:table', ['Option added by @hook option example:table']);
+
+        $expectedOutputWithFrench = <<<EOT
+ ------ ------ -------
+  I      II     III
+ ------ ------ -------
+  One    Two    Three
+  Eins   Zwei   Drei
+  Ichi   Ni     San
+  Uno    Dos    Tres
+  Un     Deux   Trois
+ ------ ------ -------
+EOT;
+        $this->assertRunCommandViaApplicationEquals('example:table --french', $expectedOutputWithFrench);
 
         $expectedAssociativeListTable = <<<EOT
  --------------- ----------------------------------------------------------------------------------------

--- a/tests/testFullStack.php
+++ b/tests/testFullStack.php
@@ -167,8 +167,15 @@ EOT;
         // is forced to 'string'.
         $this->assertRunCommandViaApplicationEquals('example:table --field=II', $expectedSingleField);
 
-        // Check the help for the example table command
-        $this->assertRunCommandViaApplicationContains('help example:table', ['Option added by @hook option example:table']);
+        // Check the help for the example table command and see if the options
+        // from the alter hook were added.
+        $this->assertRunCommandViaApplicationContains('help example:table',
+            [
+                'Option added by @hook option example:table',
+                'example:table --french',
+                'Add a row with French numbers.'
+            ]
+        );
 
         $expectedOutputWithFrench = <<<EOT
  ------ ------ -------


### PR DESCRIPTION
This allows hooks to add @option and @usage annotations that will be attached to the help text of the command(s) they hook.

See https://github.com/drush-ops/drush/issues/2336