### PR TITLE
Better name for getAnnotations() methods

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -107,7 +107,7 @@ class AnnotatedCommand extends Command
         $this->setDescription($commandInfo->getDescription());
         $this->setHelp($commandInfo->getHelp());
         $this->setAliases($commandInfo->getAliases());
-        $this->setAnnotationData($commandInfo->getAnnotationsForCommand());
+        $this->setAnnotationData($commandInfo->getAnnotations());
         foreach ($commandInfo->getExampleUsages() as $usage => $description) {
             // Symfony Console does not support attaching a description to a usage
             $this->addUsage($usage);

--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -283,7 +283,7 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         $automaticOptions = [];
         $formatManager = $this->commandProcessor()->formatterManager();
         if ($formatManager) {
-            $annotationData = $commandInfo->getAnnotationsForCommand()->getArrayCopy();
+            $annotationData = $commandInfo->getAnnotations()->getArrayCopy();
             $formatterOptions = new FormatterOptions($annotationData);
             $dataType = $commandInfo->getReturnType();
             $automaticOptions = $formatManager->automaticOptions($formatterOptions, $dataType);

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -156,7 +156,7 @@ class CommandInfo
      *
      * @return AnnotationData
      */
-    public function getAnnotations()
+    public function getRawAnnotations()
     {
         $this->parseDocBlock();
         return $this->otherAnnotations;
@@ -172,10 +172,10 @@ class CommandInfo
      *
      * @return AnnotationData
      */
-    public function getAnnotationsForCommand()
+    public function getAnnotations()
     {
         return new AnnotationData(
-            $this->getAnnotations()->getArrayCopy() +
+            $this->getRawAnnotations()->getArrayCopy() +
             [
                 'command' => $this->getName(),
             ]

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -330,7 +330,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('hookTestAnnotatedHook', $hookCallback[0][1]);
 
         $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'testAnnotationHook');
-        $annotationData = $commandInfo->getAnnotations();
+        $annotationData = $commandInfo->getRawAnnotations();
         $this->assertEquals('hookme,before,after', implode(',', $annotationData->keys()));
         $this->assertEquals('@hookme,@before,@after', implode(',', array_map(function ($item) { return "@$item"; }, $annotationData->keys())));
 
@@ -362,7 +362,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('hookAddCommandName', $hookCallback[0][1]);
 
         $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'alterMe');
-        $annotationData = $commandInfo->getAnnotations();
+        $annotationData = $commandInfo->getRawAnnotations();
         $this->assertEquals('command,addmycommandname', implode(',', $annotationData->keys()));
 
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
@@ -374,9 +374,9 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'splendiferous from alter-me');
 
         $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'alterMeToo');
-        $annotationData = $commandInfo->getAnnotations();
+        $annotationData = $commandInfo->getRawAnnotations();
         $this->assertEquals('addmycommandname', implode(',', $annotationData->keys()));
-        $annotationData = $commandInfo->getAnnotationsForCommand();
+        $annotationData = $commandInfo->getAnnotations();
         $this->assertEquals('addmycommandname,command', implode(',', $annotationData->keys()));
 
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);


### PR DESCRIPTION
Rename getAnnotations() to getRawAnnotations(), and getAnnotationsForCommand() to getAnnotations().