### PR TITLE
CommandInfo alter hook

### DIFF
--- a/src/AnnotationData.php
+++ b/src/AnnotationData.php
@@ -5,7 +5,12 @@ class AnnotationData extends \ArrayObject
 {
     public function get($key, $default)
     {
-        return isset($this[$key]) ? $this[$key] : $default;
+        return $this->has($key) ? $this[$key] : $default;
+    }
+
+    public function has($key)
+    {
+        return isset($this[$key]);
     }
 
     public function keys()

--- a/src/CommandInfoAltererInterface.php
+++ b/src/CommandInfoAltererInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Consolidation\AnnotatedCommand;
+
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+
+interface CommandInfoAltererInterface
+{
+    public function alterCommandInfo(CommandInfo $commandInfo, $commandFileInstance);
+}

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -219,6 +219,14 @@ class CommandInfo
     }
 
     /**
+     * Remove an annotation that was previoudly set.
+     */
+    public function removeAnnotation($name)
+    {
+        unset($this->otherAnnotations[$name]);
+    }
+
+    /**
      * Get the synopsis of the command (~first line).
      *
      * @return string

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -43,6 +43,7 @@ class ExampleCommandFile
      * @aliases c
      * @usage bet alpha --flip
      *   Concatenate "alpha" and "bet".
+     * @arbitrary This annotation is here merely as a marker used in testing.
      */
     public function myCat($one, $two = '', $options = ['flip' => false])
     {

--- a/tests/src/ExampleCommandInfoAlterer.php
+++ b/tests/src/ExampleCommandInfoAlterer.php
@@ -1,0 +1,15 @@
+<?php
+namespace Consolidation\TestUtils;
+
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Consolidation\AnnotatedCommand\CommandInfoAltererInterface;
+
+class ExampleCommandInfoAlterer implements CommandInfoAltererInterface
+{
+    public function alterCommandInfo(CommandInfo $commandInfo, $commandFileInstance)
+    {
+        if ($commandInfo->hasAnnotation('arbitrary')) {
+            $commandInfo->addAnnotation('dynamic', "This annotation was dynamically added by ExampleCommandInfoAlterer");
+        }
+    }
+}

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Application;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
+use Consolidation\TestUtils\ExampleCommandInfoAlterer;
 
 class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
 {
@@ -37,6 +38,30 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
 
         $input = new StringInput('arithmatic 2 3 --negate');
         $this->assertRunCommandViaApplicationEquals($command, $input, '-5');
+    }
+
+    /**
+     * Test CommandInfo command annotation altering.
+     */
+    function testAnnotatedCommandInfoAlteration()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'myCat');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $annotationData = $command->getAnnotationData();
+        $this->assertTrue($annotationData->has('arbitrary'));
+        $this->assertFalse($annotationData->has('dynamic'));
+
+        $this->commandFactory->addCommandInfoAlterer(new ExampleCommandInfoAlterer());
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $annotationData = $command->getAnnotationData();
+        $this->assertTrue($annotationData->has('arbitrary'));
+        $this->assertTrue($annotationData->has('dynamic'));
     }
 
     function testMyCatCommand()


### PR DESCRIPTION
Provide a hook to allow commandinfo to be altered just before an annotated command is created.
