### PR TITLE
Support output formatter wordwraping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ It is also possible to add InputInterface or OutputInterface parameters to any a
 
 ## API Usage
 
+If you would like to use Annotated Commands to build a commandline tool, it is recommended that you use [Robo as a framework](http://robo.li/framework.md), as it will set up all of the various command classes for you. If you would like to integrate Annotated Commands into some other framework, see the sections below.
+
+### Set up Command Factory and Instantiate Commands
+
 To use annotated commands in an application, pass an instance of your command class in to AnnotatedCommandFactory::createCommandsFromClass(). The result will be a list of Commands that may be added to your application.
 ```php
 $myCommandClassInstance = new MyCommandClass();
@@ -182,6 +186,8 @@ Note that the `setFormatterManager()` operation is optional; omit this if not us
 
 A CommandInfoAltererInterface can be added via AnnotatedCommandFactory::addCommandInfoAlterer(); it will be given the opportunity to adjust every CommandInfo object parsed from a command file prior to the creation of commands.
 
+### Command File Discovery
+
 A discovery class, CommandFileDiscovery, is also provided to help find command files on the filesystem. Usage is as follows:
 ```php
 $discovery = new CommandFileDiscovery();
@@ -198,6 +204,20 @@ If different namespaces are used at different command file paths, change the cal
 $myCommandFiles = $discovery->discover(['\Ns1' => $path1, '\Ns2' => $path2]);
 ```
 As a shortcut for the above, the method `discoverNamespaced()` will take the last directory name of each path, and append it to the base namespace provided. This matches the conventions used by Drupal modules, for example.
+
+### Configuring Output Formatts (e.g. to enable wordwrap)
+
+The Output Formatters project supports automatic formatting of tabular output. In order for wordwrapping to work correctly, the terminal width must be passed in to the Output Formatters handlers via `FormatterOptions::setWidth()`.
+
+In the Annotated Commands project, this is done via dependency injection. If a `PrepareFormatter` object is passed to `CommandProcessor::addPrepareFormatter()`, then it will be given an opportunity to set properties on the `FormatterOptions` when it is created.
+
+A `PrepareTerminalWidthOption` class is provided to use the Symfony Application class to fetch the terminal width, and provide it to the FormatterOptions. It is injected as follows:
+```php
+$terminalWidthOption = new PrepareTerminalWidthOption();
+$terminalWidthOption->setApplication($application);
+$commandFactory->commandProcessor()->addPrepareFormatter($terminalWidthOption);
+```
+To provide greater control over the width used, create your own `PrepareTerminalWidthOption` subclass, and adjust the width as needed.
 
 ## Other Callbacks
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "consolidation/output-formatters": "~2|~3",
+        "consolidation/output-formatters": "^3.1",
         "psr/log": "~1",
         "symfony/console": "^2.8|~3",
         "symfony/event-dispatcher": "^2.5|~3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ca5fddeb022bbd342f0b96bab203c3af",
-    "content-hash": "8a694bf346370c987395a0a498036552",
+    "hash": "04748d0ec38556e6528cf09857407164",
+    "content-hash": "45e07d492ec9a6d4a644fd03903f7da9",
     "packages": [
         {
             "name": "consolidation/output-formatters",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "31aac0f6ffd76833a70a12ba7fb3e428f78b55ef"
+                "reference": "11b57c6e465d782e47ff216a0bbda6e7d073c5e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/31aac0f6ffd76833a70a12ba7fb3e428f78b55ef",
-                "reference": "31aac0f6ffd76833a70a12ba7fb3e428f78b55ef",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/11b57c6e465d782e47ff216a0bbda6e7d073c5e6",
+                "reference": "11b57c6e465d782e47ff216a0bbda6e7d073c5e6",
                 "shasum": ""
             },
             "require": {
@@ -54,7 +54,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2016-11-14 18:44:33"
+            "time": "2016-11-18 03:37:26"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1036,16 +1036,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -1081,7 +1081,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
@@ -1271,16 +1271,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "ce2bda23a56456f19e35d98241446b581f648c14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ce2bda23a56456f19e35d98241446b581f648c14",
+                "reference": "ce2bda23a56456f19e35d98241446b581f648c14",
                 "shasum": ""
             },
             "require": {
@@ -1331,7 +1331,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-17 14:39:37"
         },
         {
             "name": "sebastian/diff",
@@ -1555,16 +1555,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "79860854756415e1cec8d186c9cf261cafd87dfc"
+                "reference": "938df7a6478e72795e5f8266cff24d06e3136f2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/79860854756415e1cec8d186c9cf261cafd87dfc",
-                "reference": "79860854756415e1cec8d186c9cf261cafd87dfc",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/938df7a6478e72795e5f8266cff24d06e3136f2e",
+                "reference": "938df7a6478e72795e5f8266cff24d06e3136f2e",
                 "shasum": ""
             },
             "require": {
@@ -1604,7 +1604,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-14 15:54:23"
+            "time": "2016-11-15 06:55:36"
         },
         {
             "name": "sebastian/version",

--- a/src/Options/PrepareFormatter.php
+++ b/src/Options/PrepareFormatter.php
@@ -1,0 +1,10 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Options;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+
+interface PrepareFormatter
+{
+    public function prepare(CommandData $commandData, FormatterOptions $options);
+}

--- a/src/Options/PrepareTerminalWidthOption.php
+++ b/src/Options/PrepareTerminalWidthOption.php
@@ -1,0 +1,69 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Options;
+
+use Symfony\Component\Console\Application;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+
+class PrepareTerminalWidthOption implements PrepareFormatter
+{
+    /** var Application */
+    protected $application;
+
+    /** var int */
+    protected $defaultWidth;
+
+    /** var int */
+    protected $maxWidth = PHP_INT_MAX;
+
+    /** var int */
+    protected $minWidth = 0;
+
+    public function __construct($defaultWidth = 0)
+    {
+        $this->defaultWidth = $defaultWidth;
+    }
+
+    public function setApplication(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    public function prepare(CommandData $commandData, FormatterOptions $options)
+    {
+        $width = $this->getTerminalWidth();
+        if (!$width) {
+            $width = $this->defaultWidth;
+        }
+
+        // Enforce minimum and maximum widths
+        $width = min($width, $this->getMaxWidth($commandData));
+        $width = max($width, $this->getMinWidth($commandData));
+
+        $options->setWidth($width);
+    }
+
+    protected function getTerminalWidth()
+    {
+        if (!$this->application) {
+            return 0;
+        }
+
+        $dimensions = $this->application->getTerminalDimensions();
+        if ($dimensions[0] == null) {
+            return 0;
+        }
+
+        return $dimensions[0];
+    }
+
+    protected function getMaxWidth(CommandData $commandData)
+    {
+        return $this->maxWidth;
+    }
+
+    protected function getMinWidth(CommandData $commandData)
+    {
+        return $this->minWidth;
+    }
+}

--- a/tests/src/ApplicationWithTerminalWidth.php
+++ b/tests/src/ApplicationWithTerminalWidth.php
@@ -1,0 +1,26 @@
+<?php
+namespace Consolidation\TestUtils;
+
+use Symfony\Component\Console\Application;
+
+class ApplicationWithTerminalWidth extends Application
+{
+    protected $width = 0;
+    protected $height = 0;
+
+    public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
+    {
+        parent::__construct($name, $version);
+    }
+
+    public function setWidthAndHeight($width, $height)
+    {
+        $this->width = $width;
+        $this->height = $height;
+    }
+
+    public function getTerminalDimensions()
+    {
+        return [ $this->width, $this->height ];
+    }
+}

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -94,6 +94,27 @@ class AlphaCommandFile
     }
 
     /**
+     * Test word wrapping
+     *
+     * @command example:wrap
+     * @field-labels
+     *   first: First
+     *   second: Second
+     *
+     * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+     */
+    public function exampleWrap()
+    {
+        $data = [
+            [
+                'first' => 'This is a really long cell that contains a lot of data. When it is rendered, it should be wrapped across multiple lines.',
+                'second' => 'This is the second column of the same table. It is also very long, and should be wrapped across multiple lines, just like the first column.',
+            ]
+        ];
+        return new RowsOfFields($data);
+    }
+
+    /**
      * @hook option example:table
      */
     public function additionalOptionForExampleTable($command, $annotationData)


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover functionality in this PR

### Summary
Support output formatter wordwrapping.

### Description
Provide a class to pass the terminal width from the Symfony Console Application object to the FormatterOptions object that needs it.  Set this up via dependency injection, so that clients can alter the behavior as needed.

