### PR TITLE
Make CommandProcessor::getFormat() call FormatterOptions::getFormat().

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "consolidation/output-formatters": "^3.1",
+        "consolidation/output-formatters": "^3.1.3",
         "psr/log": "~1",
         "symfony/console": "^2.8|~3",
         "symfony/event-dispatcher": "^2.5|~3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "04748d0ec38556e6528cf09857407164",
-    "content-hash": "45e07d492ec9a6d4a644fd03903f7da9",
+    "hash": "3022aec17694795060ac3d71280fbc23",
+    "content-hash": "3053742fe70568ac2d3264b50fad5a41",
     "packages": [
         {
             "name": "consolidation/output-formatters",
-            "version": "3.1.0",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "11b57c6e465d782e47ff216a0bbda6e7d073c5e6"
+                "reference": "1e6c6ab49904a31c310940ec4efccf5f36e386e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/11b57c6e465d782e47ff216a0bbda6e7d073c5e6",
-                "reference": "11b57c6e465d782e47ff216a0bbda6e7d073c5e6",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/1e6c6ab49904a31c310940ec4efccf5f36e386e4",
+                "reference": "1e6c6ab49904a31c310940ec4efccf5f36e386e4",
                 "shasum": ""
             },
             "require": {
@@ -54,7 +54,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2016-11-18 03:37:26"
+            "time": "2016-11-18 23:04:31"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -200,30 +200,21 @@ class CommandProcessor
      *
      * @return string
      */
-    protected function getFormat($options)
+    protected function getFormat(FormatterOptions $options)
     {
         // In Symfony Console, there is no way for us to differentiate
         // between the user specifying '--format=table', and the user
         // not specifying --format when the default value is 'table'.
         // Therefore, we must make --field always override --format; it
         // cannot become the default value for --format.
-        if (!empty($options['field'])) {
+        if ($options->get('field')) {
             return 'string';
         }
-        $options += [
-            'default-format' => '',
-            'pipe' => '',
-        ];
-        $options += [
-            'format' => $options['default-format'],
-            'format-pipe' => $options['default-format'],
-        ];
-
-        $format = $options['format'];
-        if ($options['pipe']) {
-            $format = $options['format-pipe'];
+        $defaults = [];
+        if ($options->get('pipe')) {
+            $defaults[FormatterOptions::DEFAULT_FORMAT] = $options->get('pipe-format');
         }
-        return $format;
+        return $options->getFormat($defaults);
     }
 
     /**
@@ -244,8 +235,8 @@ class CommandProcessor
      */
     protected function writeUsingFormatter(OutputInterface $output, $structuredOutput, CommandData $commandData)
     {
-        $format = $this->getFormat($commandData->input()->getOptions());
         $formatterOptions = $this->createFormatterOptions($commandData);
+        $format = $this->getFormat($formatterOptions);
         $this->formatterManager->write(
             $output,
             $format,

--- a/tests/testFullStack.php
+++ b/tests/testFullStack.php
@@ -251,7 +251,7 @@ EOT;
   lines.              the first column.
  ------------------- --------------------
 EOT;
-        $this->application->setWidthAndHeight(40, 24);
+        $this->application->setWidthAndHeight(42, 24);
         $this->assertRunCommandViaApplicationEquals('example:wrap', $expectedWrappedOutput);
     }
 


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
'pipe' option not working right in Drush