### PR TITLE
Custom help command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "consolidation/output-formatters": "^3.1.3",
+        "consolidation/output-formatters": "^3.1.5",
         "psr/log": "~1",
         "symfony/console": "^2.8|~3",
         "symfony/event-dispatcher": "^2.5|~3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3022aec17694795060ac3d71280fbc23",
-    "content-hash": "3053742fe70568ac2d3264b50fad5a41",
+    "hash": "bedcfecfbebad9ebb586bb7d85e5e88c",
+    "content-hash": "43d976abb943b9d320d44ee1b5696733",
     "packages": [
         {
             "name": "consolidation/output-formatters",
-            "version": "3.1.3",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "1e6c6ab49904a31c310940ec4efccf5f36e386e4"
+                "reference": "cc821a08b7bd89511038aa081625cb5b573960f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/1e6c6ab49904a31c310940ec4efccf5f36e386e4",
-                "reference": "1e6c6ab49904a31c310940ec4efccf5f36e386e4",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/cc821a08b7bd89511038aa081625cb5b573960f6",
+                "reference": "cc821a08b7bd89511038aa081625cb5b573960f6",
                 "shasum": ""
             },
             "require": {
@@ -54,7 +54,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2016-11-18 23:04:31"
+            "time": "2016-11-23 23:10:13"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -251,16 +251,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065"
+                "reference": "5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c99da1119ae61e15de0e4829196b9fba6f73d065",
-                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6",
+                "reference": "5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6",
                 "shasum": ""
             },
             "require": {
@@ -308,20 +308,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-06 01:44:51"
+            "time": "2016-11-16 22:17:09"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
+                "reference": "c058661c32f5b462722e36d120905940089cbd9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/c058661c32f5b462722e36d120905940089cbd9a",
+                "reference": "c058661c32f5b462722e36d120905940089cbd9a",
                 "shasum": ""
             },
             "require": {
@@ -365,11 +365,11 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-11-15 12:55:20"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -429,16 +429,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f"
+                "reference": "9925935bf7144f9e4d2b976905881b4face036fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
-                "reference": "205b5ffbb518a98ba2ae60a52656c4a31ab00c6f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9925935bf7144f9e4d2b976905881b4face036fb",
+                "reference": "9925935bf7144f9e4d2b976905881b4face036fb",
                 "shasum": ""
             },
             "require": {
@@ -474,7 +474,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-28 00:11:12"
+            "time": "2016-11-03 08:04:31"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -581,20 +581,20 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -603,7 +603,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -627,7 +627,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "packages-dev": [
@@ -780,16 +780,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -797,10 +797,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -838,7 +839,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1085,16 +1086,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.28",
+            "version": "4.8.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "558a3a0d28b4cb7e4a593a4fbd2220e787076225"
+                "reference": "f19d481b468b76a7fb55eb2b772ed487e484891e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/558a3a0d28b4cb7e4a593a4fbd2220e787076225",
-                "reference": "558a3a0d28b4cb7e4a593a4fbd2220e787076225",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f19d481b468b76a7fb55eb2b772ed487e484891e",
+                "reference": "f19d481b468b76a7fb55eb2b772ed487e484891e",
                 "shasum": ""
             },
             "require": {
@@ -1110,7 +1111,7 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
@@ -1153,7 +1154,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-14 06:25:28"
+            "time": "2016-11-20 10:35:28"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1271,22 +1272,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ce2bda23a56456f19e35d98241446b581f648c14"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ce2bda23a56456f19e35d98241446b581f648c14",
-                "reference": "ce2bda23a56456f19e35d98241446b581f648c14",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -1331,7 +1332,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-17 14:39:37"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -1721,16 +1722,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "949e7e846743a7f9e46dc50eb639d5fde1f53341"
+                "reference": "ab4fa32ffe6e625f9b7444e5e8d4702a0bc3ad7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/949e7e846743a7f9e46dc50eb639d5fde1f53341",
-                "reference": "949e7e846743a7f9e46dc50eb639d5fde1f53341",
+                "url": "https://api.github.com/repos/symfony/config/zipball/ab4fa32ffe6e625f9b7444e5e8d4702a0bc3ad7a",
+                "reference": "ab4fa32ffe6e625f9b7444e5e8d4702a0bc3ad7a",
                 "shasum": ""
             },
             "require": {
@@ -1770,11 +1771,11 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-25 08:27:07"
+            "time": "2016-11-03 08:04:31"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -1823,7 +1824,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -1872,16 +1873,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
+                "reference": "9da375317228e54f4ea1b013b30fa47417e84943"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/9da375317228e54f4ea1b013b30fa47417e84943",
+                "reference": "9da375317228e54f4ea1b013b30fa47417e84943",
                 "shasum": ""
             },
             "require": {
@@ -1917,7 +1918,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 18:41:13"
+            "time": "2016-11-18 21:05:29"
         }
     ],
     "aliases": [],

--- a/src/Help/HelpCommand.php
+++ b/src/Help/HelpCommand.php
@@ -1,0 +1,48 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Help;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Descriptor\XmlDescriptor;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class HelpCommand
+{
+    /** var Application */
+    protected $application;
+
+    /**
+     * Create a help document from a Symfony Console command
+     */
+    public function __construct(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    public function getApplication()
+    {
+        return $this->application;
+    }
+
+    /**
+     * Run the help command
+     *
+     * @command my-help
+     * @return \Consolidation\AnnotatedCommand\Help\HelpDocument
+     */
+    public function help($commandName = 'help')
+    {
+        $command = $this->getApplication()->find($commandName);
+
+        $helpDocument = $this->getHelpDocument($command);
+        return $helpDocument;
+    }
+
+    /**
+     * Create a help document.
+     */
+    protected function getHelpDocument($command)
+    {
+        return new HelpDocument($command);
+    }
+}

--- a/src/Help/HelpDocument.php
+++ b/src/Help/HelpDocument.php
@@ -1,0 +1,65 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Help;
+
+use Consolidation\OutputFormatters\StructuredData\Xml\DomDataInterface;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Descriptor\XmlDescriptor;
+
+class HelpDocument implements DomDataInterface
+{
+    /** var Command */
+    protected $command;
+
+    /** var \DOMDocument */
+    protected $dom;
+
+    /**
+     * Create a help document from a Symfony Console command
+     */
+    public function __construct(Command $command)
+    {
+        $dom = static::generateBaseHelpDom($command);
+        $dom = static::alterHelpDocument($command, $dom);
+
+        $this->command = $command;
+        $this->dom = $dom;
+    }
+
+    /**
+     * Convert data into a \DomDocument.
+     *
+     * @return \DomDocument
+     */
+    public function getDomData()
+    {
+        return $this->dom;
+    }
+
+    /**
+     * Create the base help DOM prior to alteration by the Command object.
+     * @param Command $command
+     * @return \DomDocument
+     */
+    private static function generateBaseHelpDom(Command $command)
+    {
+        // Use Symfony to generate xml text. If other formats are
+        // requested, convert from xml to the desired form.
+        $descriptor = new XmlDescriptor();
+        return $descriptor->getCommandDocument($command);
+    }
+
+    /**
+     * Alter the DOM document per the command object
+     * @param Command $command
+     * @param \DomDocument $dom
+     * @return \DomDocument
+     */
+    private static function alterHelpDocument(Command $command, \DomDocument $dom)
+    {
+        if ($command instanceof HelpDocumentAlter) {
+            $dom = $command->helpDocumentAlter($dom);
+        }
+        return $dom;
+    }
+}

--- a/src/Help/HelpDocumentAlter.php
+++ b/src/Help/HelpDocumentAlter.php
@@ -1,0 +1,7 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Help;
+
+interface HelpDocumentAlter
+{
+    public function helpDocumentAlter(\DomDocument $dom);
+}

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -59,6 +59,11 @@ class CommandInfo
     protected $exampleUsage = [];
 
     /**
+     * @var array
+     */
+    protected $topics = [];
+
+    /**
      * @var AnnotationData
      */
     protected $otherAnnotations;
@@ -316,6 +321,29 @@ class CommandInfo
     public function setExampleUsage($usage, $description)
     {
         $this->exampleUsage[$usage] = $description;
+        return $this;
+    }
+
+    /**
+     * Return the topics for this command.
+     *
+     * @return string[]
+     */
+    public function getTopics()
+    {
+        $this->parseDocBlock();
+        return $this->topics;
+    }
+
+    /**
+     * Add a topic
+     *
+     * @param string $topic The topic command
+     * @param string $description An explanation of what the topic is about.
+     */
+    public function setTopic($topic, $description)
+    {
+        $this->topics[$topic] = $description;
         return $this;
     }
 

--- a/src/Parser/Internal/AbstractCommandDocBlockParser.php
+++ b/src/Parser/Internal/AbstractCommandDocBlockParser.php
@@ -34,6 +34,7 @@ abstract class AbstractCommandDocBlockParser
         'default' => 'processDefaultTag',
         'aliases' => 'processAliases',
         'usage' => 'processUsageTag',
+        'topic' => 'processTopicTag',
         'description' => 'processAlternateDescriptionTag',
         'desc' => 'processAlternateDescriptionTag',
     ];
@@ -158,6 +159,18 @@ abstract class AbstractCommandDocBlockParser
         $description = static::removeLineBreaks(implode("\n", $lines));
 
         $this->commandInfo->setExampleUsage($usage, $description);
+    }
+
+    /**
+     * Store the data from a @@topic annotation in our topics list.
+     */
+    protected function processTopicTag($tag)
+    {
+        $lines = explode("\n", $this->getTagContents($tag));
+        $topic = array_shift($lines);
+        $description = static::removeLineBreaks(implode("\n", $lines));
+
+        $this->commandInfo->setTopic($topic, $description);
     }
 
     /**

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -72,17 +72,23 @@ class AlphaCommandFile
      * Test command with formatters
      *
      * @command example:table
+     * @param $unused An unused argument
      * @field-labels
      *   first: I
      *   second: II
      *   third: III
-     * @usage example:table --format=yaml
-     * @usage example:table --format=csv
+     * @usage example:table --format=yml
+     *   Show the example table in yml format.
      * @usage example:table --fields=first,third
-     * @usage example:table --fields=III,II
+     *   Show only the first and third fields in the table.
+     * @usage example:table --fields=II,III
+     *   Note that either the field ID or the visible field label may be used.
+     * @aliases extab
+     * @topic docs-tables
+     *   Hypothetical documentation on tables
      * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
      */
-    public function exampleTable($options = ['format' => 'table', 'fields' => ''])
+    public function exampleTable($unused = '', $options = ['format' => 'table', 'fields' => ''])
     {
         $outputData = [
             [ 'first' => 'One',  'second' => 'Two',  'third' => 'Three' ],

--- a/tests/testHelp.php
+++ b/tests/testHelp.php
@@ -1,0 +1,317 @@
+<?php
+namespace Consolidation\AnnotatedCommand;
+
+use Consolidation\AnnotatedCommand\Help\HelpCommand;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\CommandProcessor;
+use Consolidation\AnnotatedCommand\Hooks\AlterResultInterface;
+use Consolidation\AnnotatedCommand\Hooks\ExtractOutputInterface;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\Hooks\ProcessResultInterface;
+use Consolidation\AnnotatedCommand\Hooks\StatusDeterminerInterface;
+use Consolidation\AnnotatedCommand\Hooks\ValidatorInterface;
+use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Consolidation\OutputFormatters\FormatterManager;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Consolidation\TestUtils\ApplicationWithTerminalWidth;
+use Consolidation\AnnotatedCommand\Options\PrepareTerminalWidthOption;
+
+/**
+ * Test our 'help' command.
+ */
+class HelpTests extends \PHPUnit_Framework_TestCase
+{
+    protected $application;
+    protected $commandFactory;
+
+    function setup()
+    {
+        $this->application = new ApplicationWithTerminalWidth('TestApplication', '0.0.0');
+        $this->commandFactory = new AnnotatedCommandFactory();
+        // $factory->addListener(...);
+        $alterOptionsEventManager = new AlterOptionsCommandEvent($this->application);
+        $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+        $eventDispatcher->addSubscriber($this->commandFactory->commandProcessor()->hookManager());
+        $eventDispatcher->addSubscriber($alterOptionsEventManager);
+        $this->application->setDispatcher($eventDispatcher);
+        $this->application->setAutoExit(false);
+
+        $discovery = new CommandFileDiscovery();
+        $discovery
+          ->setSearchPattern('*CommandFile.php')
+          ->setIncludeFilesAtBase(false)
+          ->setSearchLocations(['alpha']);
+
+        chdir(__DIR__);
+        $commandFiles = $discovery->discover('.', '\Consolidation\TestUtils');
+
+        $formatter = new FormatterManager();
+        $formatter->addDefaultFormatters();
+        $formatter->addDefaultSimplifiers();
+        $terminalWidthOption = new PrepareTerminalWidthOption();
+        $terminalWidthOption->setApplication($this->application);
+        $this->commandFactory->commandProcessor()->setFormatterManager($formatter);
+        $this->commandFactory->commandProcessor()->addPrepareFormatter($terminalWidthOption);
+
+        $this->commandFactory->setIncludeAllPublicMethods(false);
+        $this->addDiscoveredCommands($this->commandFactory, $commandFiles);
+
+        $helpCommandfile = new HelpCommand($this->application);
+        $commandList = $this->commandFactory->createCommandsFromClass($helpCommandfile);
+        foreach ($commandList as $command) {
+            $this->application->add($command);
+        }
+    }
+
+    public function addDiscoveredCommands($factory, $commandFiles) {
+        foreach ($commandFiles as $path => $commandClass) {
+            $this->assertFileExists($path);
+            if (!class_exists($commandClass)) {
+                include $path;
+            }
+            $commandInstance = new $commandClass();
+            $commandList = $factory->createCommandsFromClass($commandInstance);
+            foreach ($commandList as $command) {
+                $this->application->add($command);
+            }
+        }
+    }
+
+    function assertRunCommandViaApplicationEquals($cmd, $expectedOutput, $expectedStatusCode = 0)
+    {
+        $input = new StringInput($cmd);
+        $output = new BufferedOutput();
+
+        $statusCode = $this->application->run($input, $output);
+        $commandOutput = trim($output->fetch());
+
+        $expectedOutput = $this->simplifyWhitespace($expectedOutput);
+        $commandOutput = $this->simplifyWhitespace($commandOutput);
+
+        $this->assertEquals($expectedOutput, $commandOutput);
+        $this->assertEquals($expectedStatusCode, $statusCode);
+    }
+
+    function simplifyWhitespace($data)
+    {
+        return trim(preg_replace('#[ \t]+$#m', '', $data));
+    }
+
+    function testHelp()
+    {
+        $expectedXML = <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<command id="example:table" name="example:table">
+  <usages>
+    <usage>example:table [--format [FORMAT]] [--fields [FIELDS]] [--field [FIELD]] [--] [&lt;unused&gt;]</usage>
+  </usages>
+  <examples>
+    <example>
+      <usage>example:table --format=yml</usage>
+      <description>Show the example table in yml format.</description>
+    </example>
+    <example>
+      <usage>example:table --fields=first,third</usage>
+      <description>Show only the first and third fields in the table.</description>
+    </example>
+    <example>
+      <usage>example:table --fields=II,III</usage>
+      <description>Note that either the field ID or the visible field label may be used.</description>
+    </example>
+  </examples>
+  <description>Test command with formatters</description>
+  <arguments>
+    <argument name="unused" is_required="0" is_array="0">
+      <description>An unused argument</description>
+      <defaults/>
+    </argument>
+  </arguments>
+  <options>
+    <option name="--format" shortcut="" accept_value="1" is_value_required="0" is_multiple="0">
+      <description>Format the result data. Available formats: csv,json,list,php,print-r,sections,string,table,tsv,var_export,xml,yaml</description>
+      <defaults>
+        <default>table</default>
+      </defaults>
+    </option>
+    <option name="--fields" shortcut="" accept_value="1" is_value_required="0" is_multiple="0">
+      <description>Available fields: I (first), II (second), III (third)</description>
+      <defaults/>
+    </option>
+    <option name="--field" shortcut="" accept_value="1" is_value_required="0" is_multiple="0">
+      <description>Select just one field, and force format to 'string'.</description>
+      <defaults/>
+    </option>
+    <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>Display this help message</description>
+    </option>
+    <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>Do not output any message</description>
+    </option>
+    <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
+    </option>
+    <option name="--version" shortcut="-V" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>Display this application version</description>
+    </option>
+    <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>Force ANSI output</description>
+    </option>
+    <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>Disable ANSI output</description>
+    </option>
+    <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>Do not ask any interactive question</description>
+    </option>
+  </options>
+  <help>Test command with formatters</help>
+  <aliases>
+    <alias>extab</alias>
+  </aliases>
+  <topics>
+    <topic>
+      <name>docs-tables</name>
+      <description>Hypothetical documentation on tables</description>
+    </topic>
+  </topics>
+</command>
+EOT;
+
+        $this->assertRunCommandViaApplicationEquals('my-help --format=xml example:table', $expectedXML);
+
+        $expectedJSON = <<<EOT
+{
+    "id": "example:table",
+    "name": "example:table",
+    "usages": [
+        "example:table [--format [FORMAT]] [--fields [FIELDS]] [--field [FIELD]] [--] [<unused>]"
+    ],
+    "examples": [
+        {
+            "usage": "example:table --format=yml",
+            "description": "Show the example table in yml format."
+        },
+        {
+            "usage": "example:table --fields=first,third",
+            "description": "Show only the first and third fields in the table."
+        },
+        {
+            "usage": "example:table --fields=II,III",
+            "description": "Note that either the field ID or the visible field label may be used."
+        }
+    ],
+    "description": "Test command with formatters",
+    "arguments": {
+        "unused": {
+            "name": "unused",
+            "is_required": "0",
+            "is_array": "0",
+            "description": "An unused argument"
+        }
+    },
+    "options": {
+        "format": {
+            "name": "--format",
+            "shortcut": "",
+            "accept_value": "1",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Format the result data. Available formats: csv,json,list,php,print-r,sections,string,table,tsv,var_export,xml,yaml",
+            "defaults": [
+                "table"
+            ]
+        },
+        "fields": {
+            "name": "--fields",
+            "shortcut": "",
+            "accept_value": "1",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Available fields: I (first), II (second), III (third)"
+        },
+        "field": {
+            "name": "--field",
+            "shortcut": "",
+            "accept_value": "1",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Select just one field, and force format to 'string'."
+        },
+        "help": {
+            "name": "--help",
+            "shortcut": "-h",
+            "accept_value": "0",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Display this help message"
+        },
+        "quiet": {
+            "name": "--quiet",
+            "shortcut": "-q",
+            "accept_value": "0",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Do not output any message"
+        },
+        "verbose": {
+            "name": "--verbose",
+            "shortcut": "-v",
+            "shortcuts": "-v|-vv|-vvv",
+            "accept_value": "0",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug"
+        },
+        "version": {
+            "name": "--version",
+            "shortcut": "-V",
+            "accept_value": "0",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Display this application version"
+        },
+        "ansi": {
+            "name": "--ansi",
+            "shortcut": "",
+            "accept_value": "0",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Force ANSI output"
+        },
+        "no-ansi": {
+            "name": "--no-ansi",
+            "shortcut": "",
+            "accept_value": "0",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Disable ANSI output"
+        },
+        "no-interaction": {
+            "name": "--no-interaction",
+            "shortcut": "-n",
+            "accept_value": "0",
+            "is_value_required": "0",
+            "is_multiple": "0",
+            "description": "Do not ask any interactive question"
+        }
+    },
+    "help": "Test command with formatters",
+    "alias": "extab",
+    "topics": {
+        "docs-tables": {
+            "name": "docs-tables",
+            "description": "Hypothetical documentation on tables"
+        }
+    }
+}
+EOT;
+        $this->assertRunCommandViaApplicationEquals('my-help --format=json example:table', $expectedJSON);
+    }
+}


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Symfony Console's help command does not render usages, examples, aliases and topics the way we'd like it to.  We'd also like to add wordwrapping. In progress.

### Description
Implement xml and json formats for custom help command. Still needs txt and md formats. Also, currently defined as my-help; must be able to use it to replace actual Symfony help command.