### PR TITLE
Bugfix: Rename @topic annotation to @topics for compatibility with Drush

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -179,10 +179,8 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
 
         // Create our own <topic> elements
         $newTopicsXML = $dom->createElement('topics');
-        foreach ($this->getTopics() as $topic => $description) {
-            $newTopicsXML->appendChild($topicXML = $dom->createElement('topic'));
-            $topicXML->appendChild($nameXML = $dom->createElement('name', $topic));
-            $topicXML->appendChild($descriptionXML = $dom->createElement('description', $description));
+        foreach ($this->getTopics() as $topic) {
+            $newTopicsXML->appendChild($topicXML = $dom->createElement('topic', $topic));
         }
 
         // Place the different elements into the <command> element in the desired order

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -59,11 +59,6 @@ class CommandInfo
     protected $exampleUsage = [];
 
     /**
-     * @var array
-     */
-    protected $topics = [];
-
-    /**
      * @var AnnotationData
      */
     protected $otherAnnotations;
@@ -331,20 +326,11 @@ class CommandInfo
      */
     public function getTopics()
     {
-        $this->parseDocBlock();
-        return $this->topics;
-    }
-
-    /**
-     * Add a topic
-     *
-     * @param string $topic The topic command
-     * @param string $description An explanation of what the topic is about.
-     */
-    public function setTopic($topic, $description)
-    {
-        $this->topics[$topic] = $description;
-        return $this;
+        if (!$this->hasAnnotation('topics')) {
+            return [];
+        }
+        $topics = $this->getAnnotation('topics');
+        return explode(',', trim($topics));
     }
 
     /**

--- a/src/Parser/Internal/AbstractCommandDocBlockParser.php
+++ b/src/Parser/Internal/AbstractCommandDocBlockParser.php
@@ -34,7 +34,6 @@ abstract class AbstractCommandDocBlockParser
         'default' => 'processDefaultTag',
         'aliases' => 'processAliases',
         'usage' => 'processUsageTag',
-        'topic' => 'processTopicTag',
         'description' => 'processAlternateDescriptionTag',
         'desc' => 'processAlternateDescriptionTag',
     ];
@@ -159,18 +158,6 @@ abstract class AbstractCommandDocBlockParser
         $description = static::removeLineBreaks(implode("\n", $lines));
 
         $this->commandInfo->setExampleUsage($usage, $description);
-    }
-
-    /**
-     * Store the data from a @@topic annotation in our topics list.
-     */
-    protected function processTopicTag($tag)
-    {
-        $lines = explode("\n", $this->getTagContents($tag));
-        $topic = array_shift($lines);
-        $description = static::removeLineBreaks(implode("\n", $lines));
-
-        $this->commandInfo->setTopic($topic, $description);
     }
 
     /**

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -88,8 +88,7 @@ class AlphaCommandFile implements CustomEventAwareInterface
      * @usage example:table --fields=II,III
      *   Note that either the field ID or the visible field label may be used.
      * @aliases extab
-     * @topic docs-tables
-     *   Hypothetical documentation on tables
+     * @topics docs-tables
      * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
      */
     public function exampleTable($unused = '', $options = ['format' => 'table', 'fields' => ''])

--- a/tests/testHelp.php
+++ b/tests/testHelp.php
@@ -176,10 +176,7 @@ class HelpTests extends \PHPUnit_Framework_TestCase
     <alias>extab</alias>
   </aliases>
   <topics>
-    <topic>
-      <name>docs-tables</name>
-      <description>Hypothetical documentation on tables</description>
-    </topic>
+    <topic>docs-tables</topic>
   </topics>
 </command>
 EOT;
@@ -304,12 +301,9 @@ EOT;
     },
     "help": "Test command with formatters",
     "alias": "extab",
-    "topics": {
-        "docs-tables": {
-            "name": "docs-tables",
-            "description": "Hypothetical documentation on tables"
-        }
-    }
+    "topics": [
+        "docs-tables"
+    ]
 }
 EOT;
         $this->assertRunCommandViaApplicationEquals('my-help --format=json example:table', $expectedJSON);


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [X] Breaks backwards compatibility (sortof)
- [X] Has tests that cover changes

### Summary
Renamed `@topic` annotation to `@topics`

### Description
The `@topics` annotation was added specifically for Drush; however, the initial implementation was wrong, as Drush uses `@topics`, and `@topic` was used here. So, this PR fixes that bug in the initial implementation. This would break anyone who relied on the buggy behavior. There shouldn't be anyone, but if there is, they should change to adapt to use `@topics`.

The `@topic` annotation is used to identify commands that are topics, so they can be collected and listed by the `topic` command.