### PR TITLE
Robustly handle trailing delimiters in CommandFileDiscovery.

### DIFF
--- a/src/CommandFileDiscovery.php
+++ b/src/CommandFileDiscovery.php
@@ -375,6 +375,12 @@ class CommandFileDiscovery
      */
     protected function joinParts($delimiter, $parts, $filterFunction)
     {
+        $parts = array_map(
+            function ($item) use ($delimiter) {
+                return rtrim($item, $delimiter);
+            },
+            $parts
+        );
         return implode(
             $delimiter,
             array_filter($parts, $filterFunction)


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
The existing code in CommandFileDiscovery::discover() fails if namespaces end with a \.

### Description
Packagist requires namespaces in autoload psr-4 sections to end with a trailing \. However, if the various CommandFileDiscovery `discover` methods end in a backslash, then discovery fails. With this PR, we accept namespaces both ways, without the trailing \ to maintain backwards compatibility with existing annotated-command clients, and with the trailing \ for clients that wish to take namespaces from a composer.json autoload section and pass them to the discovery class.

