### PR TITLE
Provide a mechanism to serialize and deserialize CommandInfo

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,33 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bedcfecfbebad9ebb586bb7d85e5e88c",
     "content-hash": "43d976abb943b9d320d44ee1b5696733",
     "packages": [
         {
             "name": "consolidation/output-formatters",
-            "version": "3.1.5",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "cc821a08b7bd89511038aa081625cb5b573960f6"
+                "reference": "c8ea5734985cea4acd6343a2465a2f71cf011c82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/cc821a08b7bd89511038aa081625cb5b573960f6",
-                "reference": "cc821a08b7bd89511038aa081625cb5b573960f6",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/c8ea5734985cea4acd6343a2465a2f71cf011c82",
+                "reference": "c8ea5734985cea4acd6343a2465a2f71cf011c82",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
                 "symfony/console": "~2.5|~3.0",
-                "symfony/finder": "~2.5|~3.0",
-                "victorjonsson/markdowndocs": "^1.3"
+                "symfony/finder": "~2.5|~3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.*",
                 "satooshi/php-coveralls": "^1.0",
-                "squizlabs/php_codesniffer": "2.*"
+                "squizlabs/php_codesniffer": "2.*",
+                "victorjonsson/markdowndocs": "^1.3"
             },
             "type": "library",
             "extra": {
@@ -54,7 +53,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2016-11-23 23:10:13"
+            "time": "2017-01-08T20:32:20+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -108,7 +107,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -153,20 +152,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -200,7 +199,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "psr/log",
@@ -247,20 +246,20 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.7",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6"
+                "reference": "4f9e449e76996adf310498a8ca955c6deebe29dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6",
-                "reference": "5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4f9e449e76996adf310498a8ca955c6deebe29dd",
+                "reference": "4f9e449e76996adf310498a8ca955c6deebe29dd",
                 "shasum": ""
             },
             "require": {
@@ -271,17 +270,19 @@
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/filesystem": "~2.8|~3.0",
                 "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
+                "symfony/filesystem": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -308,20 +309,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-16 22:17:09"
+            "time": "2017-01-08T20:47:33+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.1.7",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "c058661c32f5b462722e36d120905940089cbd9a"
+                "reference": "810ba5c1c5352a4ddb15d4719e8936751dff0b05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/c058661c32f5b462722e36d120905940089cbd9a",
-                "reference": "c058661c32f5b462722e36d120905940089cbd9a",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/810ba5c1c5352a4ddb15d4719e8936751dff0b05",
+                "reference": "810ba5c1c5352a4ddb15d4719e8936751dff0b05",
                 "shasum": ""
             },
             "require": {
@@ -338,7 +339,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -365,20 +366,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-15 12:55:20"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.7",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc"
+                "reference": "9137eb3a3328e413212826d63eeeb0217836e2b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
-                "reference": "28b0832b2553ffb80cabef6a7a812ff1e670c0bc",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9137eb3a3328e413212826d63eeeb0217836e2b6",
+                "reference": "9137eb3a3328e413212826d63eeeb0217836e2b6",
                 "shasum": ""
             },
             "require": {
@@ -398,7 +399,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -425,20 +426,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-13 06:28:43"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.1.7",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "9925935bf7144f9e4d2b976905881b4face036fb"
+                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/9925935bf7144f9e4d2b976905881b4face036fb",
-                "reference": "9925935bf7144f9e4d2b976905881b4face036fb",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8c71141cae8e2957946b403cc71a67213c0380d6",
+                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6",
                 "shasum": ""
             },
             "require": {
@@ -447,7 +448,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -474,7 +475,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 08:04:31"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -533,51 +534,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
-        },
-        {
-            "name": "victorjonsson/markdowndocs",
-            "version": "1.3.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/victorjonsson/PHP-Markdown-Documentation-Generator.git",
-                "reference": "a8244617cdce4804cd94ea508c82e8d7e29a273a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/victorjonsson/PHP-Markdown-Documentation-Generator/zipball/a8244617cdce4804cd94ea508c82e8d7e29a273a",
-                "reference": "a8244617cdce4804cd94ea508c82e8d7e29a273a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.0",
-                "symfony/console": ">=2.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "3.7.23"
-            },
-            "bin": [
-                "bin/phpdoc-md"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "PHPDocsMD": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Victor Jonsson",
-                    "email": "kontakt@victorjonsson.se"
-                }
-            ],
-            "description": "Command line tool for generating markdown-formatted class documentation",
-            "homepage": "https://github.com/victorjonsson/PHP-Markdown-Documentation-Generator",
-            "time": "2016-10-11 21:10:19"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -627,7 +584,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "packages-dev": [
@@ -683,7 +640,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -776,7 +733,7 @@
                 "web service"
             ],
             "abandoned": "guzzlehttp/guzzle",
-            "time": "2014-01-28 22:29:15"
+            "time": "2014-01-28T22:29:15+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -839,7 +796,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -901,20 +858,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -948,7 +905,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -989,7 +946,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1033,7 +990,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1082,20 +1039,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.29",
+            "version": "4.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f19d481b468b76a7fb55eb2b772ed487e484891e"
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f19d481b468b76a7fb55eb2b772ed487e484891e",
-                "reference": "f19d481b468b76a7fb55eb2b772ed487e484891e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
                 "shasum": ""
             },
             "require": {
@@ -1154,7 +1111,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-20 10:35:28"
+            "time": "2016-12-09T02:45:31+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1210,7 +1167,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -1268,7 +1225,7 @@
                 "github",
                 "test"
             ],
-            "time": "2016-01-20 17:35:46"
+            "time": "2016-01-20T17:35:46+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1332,7 +1289,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19 09:18:40"
+            "time": "2016-11-19T09:18:40+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1384,7 +1341,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1434,7 +1391,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1501,7 +1458,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1552,7 +1509,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1605,7 +1562,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-15 06:55:36"
+            "time": "2016-11-15T06:55:36+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1640,20 +1597,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
+                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
-                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9b324f3a1132459a7274a0ace2e1b766ba80930f",
+                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f",
                 "shasum": ""
             },
             "require": {
@@ -1718,25 +1675,28 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-09-01 23:53:02"
+            "time": "2016-11-30T04:02:31+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v3.1.7",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "ab4fa32ffe6e625f9b7444e5e8d4702a0bc3ad7a"
+                "reference": "c5ea878b5a7f6a01b9a2f182f905831711b9ff3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/ab4fa32ffe6e625f9b7444e5e8d4702a0bc3ad7a",
-                "reference": "ab4fa32ffe6e625f9b7444e5e8d4702a0bc3ad7a",
+                "url": "https://api.github.com/repos/symfony/config/zipball/c5ea878b5a7f6a01b9a2f182f905831711b9ff3f",
+                "reference": "c5ea878b5a7f6a01b9a2f182f905831711b9ff3f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
                 "symfony/filesystem": "~2.8|~3.0"
+            },
+            "require-dev": {
+                "symfony/yaml": "~3.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -1744,7 +1704,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1771,20 +1731,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 08:04:31"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.1.7",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "0565b61bf098cb4dc09f4f103f033138ae4f42c6"
+                "reference": "a0c6ef2dc78d33b58d91d3a49f49797a184d06f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0565b61bf098cb4dc09f4f103f033138ae4f42c6",
-                "reference": "0565b61bf098cb4dc09f4f103f033138ae4f42c6",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a0c6ef2dc78d33b58d91d3a49f49797a184d06f4",
+                "reference": "a0c6ef2dc78d33b58d91d3a49f49797a184d06f4",
                 "shasum": ""
             },
             "require": {
@@ -1793,7 +1753,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1820,20 +1780,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-18 04:30:12"
+            "time": "2017-01-08T20:47:33+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.1.7",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1"
+                "reference": "9aa0b51889c01bca474853ef76e9394b02264464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/bb42806b12c5f89db4ebf64af6741afe6d8457e1",
-                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/9aa0b51889c01bca474853ef76e9394b02264464",
+                "reference": "9aa0b51889c01bca474853ef76e9394b02264464",
                 "shasum": ""
             },
             "require": {
@@ -1842,7 +1802,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1869,29 +1829,35 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.7",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "9da375317228e54f4ea1b013b30fa47417e84943"
+                "reference": "50eadbd7926e31842893c957eca362b21592a97d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/9da375317228e54f4ea1b013b30fa47417e84943",
-                "reference": "9da375317228e54f4ea1b013b30fa47417e84943",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/50eadbd7926e31842893c957eca362b21592a97d",
+                "reference": "50eadbd7926e31842893c957eca362b21592a97d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1918,7 +1884,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-18 21:05:29"
+            "time": "2017-01-03T13:51:32+00:00"
         }
     ],
     "aliases": [],

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -49,7 +49,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
         // AnnotatedCommand.  Alternately, we break out a new subclass.
         // The command factory instantiates the subclass.
         if (get_class($this) != 'Consolidation\AnnotatedCommand\AnnotatedCommand') {
-            $commandInfo = new CommandInfo($this, 'execute');
+            $commandInfo = CommandInfo::create($this, 'execute');
             if (!isset($name)) {
                 $name = $commandInfo->getName();
             }

--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -156,7 +156,7 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         );
 
         foreach ($commandMethodNames as $commandMethodName) {
-            $commandInfoList[] = new CommandInfo($classNameOrInstance, $commandMethodName);
+            $commandInfoList[] = CommandInfo::create($classNameOrInstance, $commandMethodName);
         }
 
         return $commandInfoList;
@@ -164,7 +164,7 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
 
     public function createCommandInfo($classNameOrInstance, $commandMethodName)
     {
-        return new CommandInfo($classNameOrInstance, $commandMethodName);
+        return CommandInfo::create($classNameOrInstance, $commandMethodName);
     }
 
     public function createCommandsFromClassInfo($commandInfoList, $commandFileInstance, $includeAllPublicMethods = null)

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -18,6 +18,11 @@ use Consolidation\AnnotatedCommand\AnnotationData;
 class CommandInfo
 {
     /**
+     * Serialization schema version. Incremented every time the serialization schema changes.
+     */
+    const SERIALIZATION_SCHEMA_VERSION = 1;
+
+    /**
      * @var \ReflectionMethod
      */
     protected $reflection;
@@ -26,7 +31,7 @@ class CommandInfo
      * @var boolean
      * @var string
     */
-    protected $docBlockIsParsed;
+    protected $docBlockIsParsed = false;
 
     /**
      * @var string
@@ -69,6 +74,11 @@ class CommandInfo
     protected $aliases = [];
 
     /**
+     * @var InputOption[]
+     */
+    protected $inputOptions;
+
+    /**
      * @var string
      */
     protected $methodName;
@@ -79,32 +89,163 @@ class CommandInfo
     protected $returnType;
 
     /**
-     * @var string
-     */
-    protected $optionParamName;
-
-    /**
      * Create a new CommandInfo class for a particular method of a class.
      *
      * @param string|mixed $classNameOrInstance The name of a class, or an
-     *   instance of it.
+     *   instance of it, or an array of cached data.
      * @param string $methodName The name of the method to get info about.
+     * @param array $cache Cached data
+     * @deprecated Use CommandInfo::create() or CommandInfo::deserialize()
+     *   instead. In the future, this constructor will be protected.
      */
-    public function __construct($classNameOrInstance, $methodName)
+    public function __construct($classNameOrInstance, $methodName, $cache = [])
     {
         $this->reflection = new \ReflectionMethod($classNameOrInstance, $methodName);
         $this->methodName = $methodName;
+
+        if (!empty($cache)) {
+            $this->constructFromCache($cache);
+            $this->docBlockIsParsed = true;
+        } else {
+            $this->constructFromClassAndMethod($classNameOrInstance, $methodName);
+        }
+    }
+
+    public static function create($classNameOrInstance, $methodName)
+    {
+        return new self($classNameOrInstance, $methodName);
+    }
+
+    public static function deserialize($cache)
+    {
+        $classNameOrInstance = $cache['class'];
+        $methodName = $cache['method_name'];
+
+        // If the cache came from a newer version, ignore it and
+        // regenerate the cached information.
+        if ($cache['schema'] > self::SERIALIZATION_SCHEMA_VERSION) {
+            return self::create($classNameOrInstance, $methodName);
+        }
+        return new self($classNameOrInstance, $methodName, $cache);
+    }
+
+    protected function constructFromClassAndMethod($classNameOrInstance, $methodName)
+    {
         $this->otherAnnotations = new AnnotationData();
         // Set up a default name for the command from the method name.
         // This can be overridden via @command or @name annotations.
-        $this->name = $this->convertName($this->reflection->name);
+        $this->name = $this->convertName($methodName);
         $this->options = new DefaultsWithDescriptions($this->determineOptionsFromParameters(), false);
         $this->arguments = $this->determineAgumentClassifications();
-        // Remember the name of the last parameter, if it holds the options.
-        // We will use this information to ignore @param annotations for the options.
-        if (!empty($this->options)) {
-            $this->optionParamName = $this->lastParameterName();
+    }
+
+    protected function constructFromCache($info_array)
+    {
+        $this->name = $info_array['name'];
+        $this->methodName = $info_array['method_name'];
+        $this->otherAnnotations = new AnnotationData((array) $info_array['annotations']);
+        $this->arguments = new DefaultsWithDescriptions();
+        $this->options = new DefaultsWithDescriptions();
+        $this->aliases = $info_array['aliases'];
+        $this->help = $info_array['help'];
+        $this->description = $info_array['description'];
+        $this->exampleUsage = $info_array['example_usages'];
+        $this->returnType = $info_array['return_type'];
+
+        foreach ((array)$info_array['arguments'] as $key => $info) {
+            $info = (array)$info;
+            $this->arguments->add($key, $info['description']);
+            if (array_key_exists('default', $info)) {
+                $this->arguments->setDefaultValue($key, $info['default']);
+            }
         }
+        foreach ((array)$info_array['options'] as $key => $info) {
+            $info = (array)$info;
+            $this->options->add($key, $info['description']);
+            if (array_key_exists('default', $info)) {
+                $this->options->setDefaultValue($key, $info['default']);
+            }
+        }
+
+        $this->input_options = [];
+        foreach ((array)$info_array['input_options'] as $i => $option) {
+            $option = (array) $option;
+            $this->inputOptions[$i] = new InputOption(
+                $option['name'],
+                $option['shortcut'],
+                $option['mode'],
+                $option['description'],
+                $option['default']
+            );
+        }
+    }
+
+    public function serialize()
+    {
+        $info = [
+            'schema' => self::SERIALIZATION_SCHEMA_VERSION,
+            'class' => $this->reflection->getDeclaringClass()->getName(),
+            'method_name' => $this->getMethodName(),
+            'name' => $this->getName(),
+            'description' => $this->getDescription(),
+            'help' => $this->getHelp(),
+            'aliases' => $this->getAliases(),
+            'annotations' => $this->getAnnotations()->getArrayCopy(),
+            // Todo: Test This.
+            'topics' => $this->getTopics(),
+            'example_usages' => $this->getExampleUsages(),
+            'return_type' => $this->getReturnType(),
+            'parameters' => [],
+            'arguments' => [],
+            'arguments' => [],
+            'options' => [],
+        ];
+        foreach ($this->arguments()->getValues() as $key => $val) {
+            $info['arguments'][$key] = [
+                'description' => $this->arguments()->getDescription($key),
+            ];
+            if ($this->arguments()->hasDefault($key)) {
+                $info['arguments'][$key]['default'] = $val;
+            }
+        }
+        foreach ($this->options()->getValues() as $key => $val) {
+            $info['options'][$key] = [
+                'description' => $this->options()->getDescription($key),
+            ];
+            if ($this->options()->hasDefault($key)) {
+                $info['options'][$key]['default'] = $val;
+            }
+        }
+        foreach ($this->getParameters() as $i => $parameter) {
+            // TODO: Also cache input/output params
+        }
+        foreach ($this->inputOptions() as $i => $option) {
+            $mode = 0;
+            if ($option->isValueRequired()) {
+                $mode |= InputOption::VALUE_REQUIRED;
+            }
+            if ($option->isValueOptional()) {
+                $mode |= InputOption::VALUE_OPTIONAL;
+            }
+            if ($option->isArray()) {
+                $mode |= InputOption::VALUE_IS_ARRAY;
+            }
+            if (!$mode) {
+                $mode = InputOption::VALUE_NONE;
+            }
+
+            $info['input_options'][$i] = [
+                'name' => $option->getName(),
+                'shortcut' => $option->getShortcut(),
+                'mode' => $mode,
+                'description' => $option->getDescription(),
+                'default' => null,
+            ];
+            if ($option->isValueOptional()) {
+                $info['input_options'][$i]['default'] = $option->getDefault();
+            }
+        }
+        return $info;
     }
 
     /**
@@ -364,14 +505,6 @@ class CommandInfo
     }
 
     /**
-     * Return the name of the last parameter if it holds the options.
-     */
-    public function optionParamName()
-    {
-        return $this->optionParamName;
-    }
-
-    /**
      * Get the inputOptions for the options associated with this CommandInfo
      * object, e.g. via @option annotations, or from
      * $options = ['someoption' => 'defaultvalue'] in the command method
@@ -380,6 +513,14 @@ class CommandInfo
      * @return InputOption[]
      */
     public function inputOptions()
+    {
+        if (!isset($this->inputOptions)) {
+            $this->inputOptions = $this->createInputOptions();
+        }
+        return $this->inputOptions;
+    }
+
+    protected function createInputOptions()
     {
         $explicitOptions = [];
 
@@ -526,16 +667,6 @@ class CommandInfo
             return [];
         }
         return $param->getDefaultValue();
-    }
-
-    protected function lastParameterName()
-    {
-        $params = $this->reflection->getParameters();
-        $param = end($params);
-        if (!$param) {
-            return '';
-        }
-        return $param->name;
     }
 
     /**

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -123,7 +123,7 @@ class CommandInfo
 
         // If the cache came from a newer version, ignore it and
         // regenerate the cached information.
-        if ($cache['schema'] > self::SERIALIZATION_SCHEMA_VERSION) {
+        if (!isset($cache['schema']) || ($cache['schema'] > self::SERIALIZATION_SCHEMA_VERSION)) {
             return self::create($classNameOrInstance, $methodName);
         }
         return new self($classNameOrInstance, $methodName, $cache);
@@ -141,6 +141,8 @@ class CommandInfo
 
     protected function constructFromCache($info_array)
     {
+        $info_array += $this->defaultSerializationData();
+
         $this->name = $info_array['name'];
         $this->methodName = $info_array['method_name'];
         $this->otherAnnotations = new AnnotationData((array) $info_array['annotations']);
@@ -195,11 +197,7 @@ class CommandInfo
             'topics' => $this->getTopics(),
             'example_usages' => $this->getExampleUsages(),
             'return_type' => $this->getReturnType(),
-            'parameters' => [],
-            'arguments' => [],
-            'arguments' => [],
-            'options' => [],
-        ];
+        ] + $this->defaultSerializationData();
         foreach ($this->arguments()->getValues() as $key => $val) {
             $info['arguments'][$key] = [
                 'description' => $this->arguments()->getDescription($key),
@@ -246,6 +244,28 @@ class CommandInfo
             }
         }
         return $info;
+    }
+
+    /**
+     * Default data for serialization.
+     * @return array
+     */
+    protected function defaultSerializationData()
+    {
+        return [
+            'description' => '',
+            'help' => '',
+            'aliases' => [],
+            'annotations' => [],
+            'topics' => [],
+            'example_usages' => [],
+            'return_type' => [],
+            'parameters' => [],
+            'arguments' => [],
+            'arguments' => [],
+            'options' => [],
+            'input_options' => [],
+        ];
     }
 
     /**

--- a/tests/testCommandInfo.php
+++ b/tests/testCommandInfo.php
@@ -22,8 +22,17 @@ class CommandInfoTests extends \PHPUnit_Framework_TestCase
      */
     function testParsing()
     {
-        $commandInfo = new CommandInfo('\Consolidation\TestUtils\ExampleCommandFile', 'testArithmatic');
+        $commandInfo = CommandInfo::create('\Consolidation\TestUtils\ExampleCommandFile', 'testArithmatic');
+        $this->assertCommandInfoIsAsExpected($commandInfo);
 
+        $serialized = $commandInfo->serialize();
+
+        $deserializedCommandInfo = CommandInfo::deserialize($serialized);
+        $this->assertCommandInfoIsAsExpected($deserializedCommandInfo);
+    }
+
+    function assertCommandInfoIsAsExpected($commandInfo)
+    {
         $this->assertEquals('test:arithmatic', $commandInfo->getName());
         $this->assertEquals(
             'This is the test:arithmatic command',
@@ -54,7 +63,7 @@ class CommandInfoTests extends \PHPUnit_Framework_TestCase
 
     function testReturnValue()
     {
-        $commandInfo = new CommandInfo('\Consolidation\TestUtils\alpha\AlphaCommandFile', 'exampleTable');
+        $commandInfo = CommandInfo::create('\Consolidation\TestUtils\alpha\AlphaCommandFile', 'exampleTable');
         $this->assertEquals('example:table', $commandInfo->getName());
         $this->assertEquals('\Consolidation\OutputFormatters\StructuredData\RowsOfFields', $commandInfo->getReturnType());
     }

--- a/tests/testFullStack.php
+++ b/tests/testFullStack.php
@@ -48,7 +48,7 @@ class FullStackTests extends \PHPUnit_Framework_TestCase
         $formatter = new FormatterManager();
         $formatter->addDefaultFormatters();
         $formatter->addDefaultSimplifiers();
-        $commandInfo = new CommandInfo('\Consolidation\TestUtils\alpha\AlphaCommandFile', 'exampleTable');
+        $commandInfo = CommandInfo::create('\Consolidation\TestUtils\alpha\AlphaCommandFile', 'exampleTable');
         $this->assertEquals('example:table', $commandInfo->getName());
         $this->assertEquals('\Consolidation\OutputFormatters\StructuredData\RowsOfFields', $commandInfo->getReturnType());
     }


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Add `serialize` and `deserialize` capabilities to CommandInfo objects to allow clients to cache command info.