### PR TITLE
Bug #70: Fix argument help for last item

### DIFF
--- a/src/Parser/Internal/AbstractCommandDocBlockParser.php
+++ b/src/Parser/Internal/AbstractCommandDocBlockParser.php
@@ -193,7 +193,7 @@ abstract class AbstractCommandDocBlockParser
         if (!isset($this->optionParamName)) {
             $this->optionParamName = '';
             $options = $this->commandInfo->options();
-            if (!empty($options)) {
+            if (!$options->isEmpty()) {
                 $this->optionParamName = $this->lastParameterName();
             }
         }


### PR DESCRIPTION
Description is omitted on the last argument if the command has no options.

### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
See #70.

This is a failing test; fix forthcoming.
