### PR TITLE
This fixes the bug preventing options provided by annotated-command's…

### DIFF
--- a/src/Options/AlterOptionsCommandEvent.php
+++ b/src/Options/AlterOptionsCommandEvent.php
@@ -58,7 +58,7 @@ class AlterOptionsCommandEvent implements EventSubscriberInterface
                 $input->bind($command->getDefinition());
             }
 
-            $nameOfCommandToDescribe = $event->getInput()->getArgument('command_name');
+            $nameOfCommandToDescribe = $event->getInput()->getArgument('command');
             $commandToDescribe = $this->application->find($nameOfCommandToDescribe);
             $this->findAndAddHookOptions($commandToDescribe);
         } else {


### PR DESCRIPTION
… option hook from appearing when we run myapp my:command -h.

### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
See https://github.com/consolidation/annotated-command/issues/73

### Description
I tested this using both symfony 2.x and 3.x.
