### PR TITLE
Provide path to command file in AnnotationData objects.

### DIFF
--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -289,7 +289,7 @@ class HookManager implements EventSubscriberInterface
     ) {
         $providers = $this->getInitializeHooks($names, $annotationData);
         foreach ($providers as $provider) {
-            $this->callInjectConfigurationHook($provider, $input, $annotationData);
+            $this->callInitializeHook($provider, $input, $annotationData);
         }
     }
 
@@ -592,10 +592,10 @@ class HookManager implements EventSubscriberInterface
         return [];
     }
 
-    protected function callInjectConfigurationHook($provider, $input, AnnotationData $annotationData)
+    protected function callInitializeHook($provider, $input, AnnotationData $annotationData)
     {
         if ($provider instanceof InitializeHookInterface) {
-            return $provider->applyConfiguration($input, $annotationData);
+            return $provider->initialize($input, $annotationData);
         }
         if (is_callable($provider)) {
             return $provider($input, $annotationData);

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -356,10 +356,14 @@ class CommandInfo
      */
     public function getAnnotations()
     {
+        // Also provide the path to the commandfile that
+        // these annotations were pulled from.
+        $path = $this->reflection->getFileName();
         return new AnnotationData(
             $this->getRawAnnotations()->getArrayCopy() +
             [
                 'command' => $this->getName(),
+                '_path' => $path,
             ]
         );
     }

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -439,7 +439,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $annotationData = $commandInfo->getRawAnnotations();
         $this->assertEquals('addmycommandname', implode(',', $annotationData->keys()));
         $annotationData = $commandInfo->getAnnotations();
-        $this->assertEquals('addmycommandname,command', implode(',', $annotationData->keys()));
+        $this->assertEquals('addmycommandname,command,_path', implode(',', $annotationData->keys()));
 
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
 


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Store the path to the commandfile in the CommandData object.

### Description
The purpose here is to facilitate a plugin manager's ability to locate the autoload file for a given plugin.
