### PR TITLE
77 array option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ class MyCommandClass
      * @command my:cat
      * @param integer $one The first parameter.
      * @param integer $two The other parameter.
+     * @option arr An option that takes multiple values.
      * @option flip Whether or not the second parameter should come first in the result.
      * @aliases c
      * @usage bet alpha --flip
      *   Concatenate "alpha" and "bet".
      */
-    public function myCat($one, $two, $options = ['flip' => false])
+    public function myCat($one, $two, $options = ['arr' => ['three'], 'flip' => false])
     {
         if ($options['flip']) {
             return "{$two}{$one}";

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -581,6 +581,13 @@ class CommandInfo
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_NONE, $description);
             } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description);
+            } elseif ($defaultValue === InputOption::VALUE_IS_ARRAY) {
+                $explicitOptions[$fullName] = new InputOption(
+                    $fullName,
+                    $shortcut,
+                    InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                    $description
+                );
             } else {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_OPTIONAL, $description, $defaultValue);
             }

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -717,7 +717,7 @@ class CommandInfo
      * is not associative if its keys are numeric, and numbered sequentially
      * from zero. All other arrays are considered to be associative.
      *
-     * @param arrau $arr The array
+     * @param array $arr The array
      * @return boolean
      */
     protected function isAssoc($arr)

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -581,11 +581,13 @@ class CommandInfo
             } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description);
             } elseif (is_array($defaultValue)) {
+                $optionality = count($defaultValue) ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
                 $explicitOptions[$fullName] = new InputOption(
                     $fullName,
                     $shortcut,
-                    InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-                    $description
+                    InputOption::VALUE_IS_ARRAY | $optionality,
+                    $description,
+                    count($defaultValue) ? $defaultValue : null
                 );
             } else {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_OPTIONAL, $description, $defaultValue);

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -581,7 +581,7 @@ class CommandInfo
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_NONE, $description);
             } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description);
-            } elseif ($defaultValue === InputOption::VALUE_IS_ARRAY) {
+            } elseif (is_array($defaultValue)) {
                 $explicitOptions[$fullName] = new InputOption(
                     $fullName,
                     $shortcut,

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -280,7 +280,6 @@ class CommandInfo
             'return_type' => [],
             'parameters' => [],
             'arguments' => [],
-            'arguments' => [],
             'options' => [],
             'input_options' => [],
             'mtime' => 0,

--- a/tests/src/ExampleAnnotatedCommand.php
+++ b/tests/src/ExampleAnnotatedCommand.php
@@ -19,12 +19,12 @@ class ExampleAnnotatedCommand extends AnnotatedCommand
     /**
      * Do the main function of the my:cat command.
      */
-    public function myCat($one, $two = '', $flip = false)
+    public function myCat($one, $two = '', $multiple = [], $flip = false)
     {
         if ($flip) {
-            return "{$two}{$one}";
+            return "{$two}{$one}" . implode('', array_reverse($multiple));
         }
-        return "{$one}{$two}";
+        return "{$one}{$two}" . implode('', $multiple);
     }
 
     /**
@@ -37,6 +37,8 @@ class ExampleAnnotatedCommand extends AnnotatedCommand
      * @arg string $one The first parameter.
      * @arg string $two The other parameter.
      * @default $two ''
+     * @option array $multiple An array of values
+     * @default $multiple []
      * @option boolean $flip Whether or not the second parameter should come first in the result.
      * @aliases c
      * @usage bet alpha --flip
@@ -46,9 +48,10 @@ class ExampleAnnotatedCommand extends AnnotatedCommand
     {
         $one = $input->getArgument('one');
         $two = $input->getArgument('two');
+        $multiple = $input->getOption('multiple');
         $flip = $input->getOption('flip');
 
-        $result = $this->myCat($one, $two, $flip);
+        $result = $this->myCat($one, $two, $multiple, $flip);
 
         // We could also just use $output->writeln($result) here,
         // but calling processResults enables the use of output

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -356,4 +356,30 @@ class ExampleCommandFile
         }
         return "nothing provided";
     }
+
+    /**
+     * This is the test:required-array-option command
+     *
+     * This command will print all the valused of passed option
+     *
+     * @param array $opts
+     * @return string
+     */
+    public function testRequiredArrayOption($opts = ['arr|a' => []])
+    {
+        return implode(' ', $opts['arr']);
+    }
+
+    /**
+     * This is the test:array-option command
+     *
+     * This command will print all the valused of passed option
+     *
+     * @param array $opts
+     * @return string
+     */
+    public function testArrayOption($opts = ['arr|a' => ['1', '2', '3']])
+    {
+        return implode(' ', $opts['arr']);
+    }
 }

--- a/tests/testAnnotatedCommand.php
+++ b/tests/testAnnotatedCommand.php
@@ -20,10 +20,10 @@ class AnnotatedCommandTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals("This command will concatenate two parameters. If the --flip flag\nis provided, then the result is the concatenation of two and one.", $command->getHelp());
         $this->assertEquals('c', implode(',', $command->getAliases()));
         // Symfony Console composes the synopsis; perhaps we should not test it. Remove if this gives false failures.
-        $this->assertEquals('my:cat [--flip] [--] <one> [<two>]', $command->getSynopsis());
+        $this->assertEquals('my:cat [--multiple MULTIPLE] [--flip] [--] <one> [<two>]', $command->getSynopsis());
         $this->assertEquals('my:cat bet alpha --flip', implode(',', $command->getUsages()));
 
-        $input = new StringInput('my:cat bet alpha --flip');
+        $input = new StringInput('my:cat b alpha --multiple=t --multiple=e --flip');
         $this->assertRunCommandViaApplicationEquals($command, $input, 'alphabet');
     }
 

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -272,6 +272,41 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'betxyzbetxyz');
     }
 
+    function testRequiredArrayOption()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'testRequiredArrayOption');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+        $this->assertEquals('test:required-array-option [-a|--arr ARR]', $command->getSynopsis());
+
+        $input = new StringInput('test:required-array-option --arr=1 --arr=2 --arr=3');
+        $this->assertRunCommandViaApplicationEquals($command, $input, '1 2 3');
+
+        $input = new StringInput('test:required-array-option -a 1 -a 2 -a 3');
+        $this->assertRunCommandViaApplicationEquals($command, $input, '1 2 3');
+    }
+
+    function testArrayOption()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'testArrayOption');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+        $this->assertEquals('test:array-option [-a|--arr [ARR]]', $command->getSynopsis());
+
+        $input = new StringInput('test:array-option');
+        $this->assertRunCommandViaApplicationEquals($command, $input, '1 2 3');
+
+        $input = new StringInput('test:array-option --arr=a --arr=b --arr=c');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'a b c');
+
+        $input = new StringInput('test:array-option -a a');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'a');
+    }
+
     function testHookedCommand()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile();


### PR DESCRIPTION
This pr allows to pass an option with multiple arguments
This commands will produce
```bash
frol-mbp@vagrant:/path$ robo parallel:run -t 10 -s api -s acceptance
frol-mbp@vagrant:/path$ robo parallel:run -t 10 --suite=api --suite=acceptance
#Above commands will produce:
array(11) {
  ["threads"]=>
  string(2) "10"
  ["suite"]=>
  array(2) {
    [0]=>
    string(3) "api"
    [1]=>
    string(10) "acceptance"
  }
  ...


frol-mbp@vagrant:/path$ robo parallel:run-test -h
Usage:
  parallel:run-test [options]
  parallel:run-test -t 5 -s api

Options:
  -t, --threads=THREADS                Number of threads to use for running the tests
  -s, --suite=SUITE                    Suite to run tests (multiple values allowed)
  -h, --help                           Display this help message
  -q, --quiet                          Do not output any message
  -V, --version                        Display this application version
      --ansi                           Force ANSI output
      --no-ansi                        Disable ANSI output
  -n, --no-interaction                 Do not ask any interactive question
      --simulate                       Run in simulated mode (show what would have happened).
      --progress-delay=PROGRESS-DELAY  Number of seconds before progress bar is displayed in long-running task collections. Default: 2s. [default: 2]
  -v|vv|vvv, --verbose                 Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```
