### PR TITLE
Add SimpleCacheInterface as a documentation interface (not enforced).

### DIFF
--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -178,6 +178,14 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
             return [];
         }
         $className = get_class($commandFileInstance);
+        // TODO: Once we typehint our data store as a SimpleCacheInterface,
+        // then we will not need to use 'method_exists' here.
+        // If the data store has a 'has' method, then we will use it.
+        // This allows the data store to throw on get if they key does not
+        // exist, if desired.
+        if (method_exists($this->getDataStore(), 'has') && !$this->getDataStore()->has($className)) {
+            return [];
+        }
         $cache_data = (array) $this->getDataStore()->get($className);
         if (!$cache_data) {
             return [];
@@ -208,12 +216,18 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
      * 'get' methods is acceptable. The key is the classname being cached,
      * and the value is a nested associative array of strings.
      *
-     * @param type $dataStore
+     * TODO: Typehint this to SimpleCacheInterface
+     *
+     * This is not done currently to allow clients to use a generic cache
+     * store that does not itself depend on the annotated-command library.
+     *
+     * @param Mixed $dataStore
      * @return type
      */
     public function setDataStore($dataStore)
     {
         $this->dataStore = $dataStore;
+        return $this;
     }
 
     /**

--- a/src/Cache/CacheWrapper.php
+++ b/src/Cache/CacheWrapper.php
@@ -1,0 +1,49 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Cache;
+
+/**
+ * Make a generic cache object conform to our expected interface.
+ */
+class CacheWrapper implements SimpleCacheInterface
+{
+    protected $dataStore;
+
+    public function __construct($dataStore)
+    {
+        $this->dataStore = $dataStore;
+    }
+
+    /**
+     * Test for an entry from the cache
+     * @param string $key
+     * @return boolean
+     */
+    public function has($key)
+    {
+        if (method_exists($this->dataStore, 'has')) {
+            return $this->dataStore->has($key);
+        }
+        $test = $this->dataStore->get($key);
+        return !empty($test);
+    }
+
+    /**
+     * Get an entry from the cache
+     * @param string $key
+     * @return array
+     */
+    public function get($key)
+    {
+        return (array) $this->dataStore->get($key);
+    }
+
+    /**
+     * Store an entry in the cache
+     * @param string $key
+     * @param array $data
+     */
+    public function set($key, $data)
+    {
+        $this->dataStore->set($key, $data);
+    }
+}

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -1,0 +1,37 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Cache;
+
+/**
+ * An empty cache that never stores or fetches any objects.
+ */
+class NullCache implements SimpleCacheInterface
+{
+    /**
+     * Test for an entry from the cache
+     * @param string $key
+     * @return boolean
+     */
+    public function has($key)
+    {
+        return false;
+    }
+
+    /**
+     * Get an entry from the cache
+     * @param string $key
+     * @return array
+     */
+    public function get($key)
+    {
+        return [];
+    }
+
+    /**
+     * Store an entry in the cache
+     * @param string $key
+     * @param array $data
+     */
+    public function set($key, $data)
+    {
+    }
+}

--- a/src/Cache/SimpleCacheInterface.php
+++ b/src/Cache/SimpleCacheInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace Consolidation\AnnotatedCommand;
+namespace Consolidation\AnnotatedCommand\Cache;
 
 /**
  * Documentation interface.

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -122,10 +122,20 @@ class CommandInfo
     {
         $cache = (array)$cache;
 
-        $classNameOrInstance = $cache['class'];
+        $className = $cache['class'];
         $methodName = $cache['method_name'];
 
-        return new self($classNameOrInstance, $methodName, $cache);
+        return new self($className, $methodName, $cache);
+    }
+
+    protected static function cachedMethodExists($cache)
+    {
+        $cache = (array)$cache;
+
+        $className = $cache['class'];
+        $methodName = $cache['method_name'];
+
+        return method_exists($className, $methodName);
     }
 
     public static function isValidSerializedData($cache)
@@ -135,7 +145,8 @@ class CommandInfo
             isset($cache['method_name']) &&
             isset($cache['mtime']) &&
             ($cache['schema'] > 0) &&
-            ($cache['schema'] <= self::SERIALIZATION_SCHEMA_VERSION);
+            ($cache['schema'] <= self::SERIALIZATION_SCHEMA_VERSION) &&
+            self::cachedMethodExists($cache);
     }
 
     public function cachedFileIsModified($cache)

--- a/src/SimpleCacheInterface.php
+++ b/src/SimpleCacheInterface.php
@@ -1,0 +1,35 @@
+<?php
+namespace Consolidation\AnnotatedCommand;
+
+/**
+ * Documentation interface.
+ *
+ * Clients that use AnnotatedCommandFactory::setDataStore()
+ * are encouraged to provide a data store that implements
+ * this interface.
+ *
+ * This is not currently required to allow clients to use a generic cache
+ * store that does not itself depend on the annotated-command library.
+ * This might be required in a future version.
+ */
+interface SimpleCacheInterface
+{
+    /**
+     * Test for an entry from the cache
+     * @param string $key
+     * @return boolean
+     */
+    public function has($key);
+    /**
+     * Get an entry from the cache
+     * @param string $key
+     * @return array
+     */
+    public function get($key);
+    /**
+     * Store an entry in the cache
+     * @param string $key
+     * @param array $data
+     */
+    public function set($key, $data);
+}

--- a/tests/src/InMemoryCacheStore.php
+++ b/tests/src/InMemoryCacheStore.php
@@ -1,0 +1,50 @@
+<?php
+namespace Consolidation\TestUtils;
+
+use Consolidation\AnnotatedCommand\Cache\SimpleCacheInterface;
+
+/**
+ * A simple in-memory cache for testing
+ */
+class InMemoryCacheStore implements SimpleCacheInterface
+{
+    protected $cache;
+
+    public function __construct()
+    {
+        $this->cache = [];
+    }
+
+    /**
+     * Test for an entry from the cache
+     * @param string $key
+     * @return boolean
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->cache);
+    }
+
+    /**
+     * Get an entry from the cache
+     * @param string $key
+     * @return array
+     */
+    public function get($key)
+    {
+        if (!$this->has($key)) {
+            return [];
+        }
+        return $this->cache[$key];
+    }
+
+    /**
+     * Store an entry in the cache
+     * @param string $key
+     * @param array $data
+     */
+    public function set($key, $data)
+    {
+        $this->cache[$key] = $data;
+    }
+}


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Add a documentation interface for the cache storage object for clarity.