### PR TITLE
Factor hook dispatchers out of the HookManager class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.4.2 - 24 Feb 2017
+
+- Add SimpleCacheInterface as a documentation interface (not enforced).
+
 ### 2.4.1 - 20 Feb 2017
 
 - Support array options: multiple options on the commandline may be passed in to options array as an array of values.

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -11,6 +11,14 @@ use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Options\PrepareFormatter;
 
+use Consolidation\AnnotatedCommand\Hooks\Dispatchers\InitializeHookDispatcher;
+use Consolidation\AnnotatedCommand\Hooks\Dispatchers\OptionsHookDispatcher;
+use Consolidation\AnnotatedCommand\Hooks\Dispatchers\InteractHookDispatcher;
+use Consolidation\AnnotatedCommand\Hooks\Dispatchers\ValidateHookDispatcher;
+use Consolidation\AnnotatedCommand\Hooks\Dispatchers\ProcessResultHookDispatcher;
+use Consolidation\AnnotatedCommand\Hooks\Dispatchers\StatusDeterminerHookDispatcher;
+use Consolidation\AnnotatedCommand\Hooks\Dispatchers\ExtracterHookDispatcher;
+
 /**
  * Process a command, including hooks and other callbacks.
  * There should only be one command processor per application.
@@ -73,7 +81,8 @@ class CommandProcessor
         $names,
         AnnotationData $annotationData
     ) {
-        return $this->hookManager()->initializeHook($input, $names, $annotationData);
+        $initializeDispatcher = new InitializeHookDispatcher($this->hookManager(), $names);
+        return $initializeDispatcher->initialize($input, $annotationData);
     }
 
     public function optionsHook(
@@ -81,7 +90,8 @@ class CommandProcessor
         $names,
         AnnotationData $annotationData
     ) {
-        $this->hookManager()->optionsHook($command, $names, $annotationData);
+        $optionsDispatcher = new OptionsHookDispatcher($this->hookManager(), $names);
+        $optionsDispatcher->getOptions($command, $annotationData);
     }
 
     public function interact(
@@ -90,7 +100,8 @@ class CommandProcessor
         $names,
         AnnotationData $annotationData
     ) {
-        return $this->hookManager()->interact($input, $output, $names, $annotationData);
+        $interactDispatcher = new InteractHookDispatcher($this->hookManager(), $names);
+        return $interactDispatcher->interact($input, $output, $annotationData);
     }
 
     public function process(
@@ -120,7 +131,8 @@ class CommandProcessor
     ) {
         // Validators return any object to signal a validation error;
         // if the return an array, it replaces the arguments.
-        $validated = $this->hookManager()->validateArguments($names, $commandData);
+        $validateDispatcher = new ValidateHookDispatcher($this->hookManager(), $names);
+        $validated = $validateDispatcher->validate($commandData);
         if (is_object($validated)) {
             return $validated;
         }
@@ -132,7 +144,8 @@ class CommandProcessor
 
     public function processResults($names, $result, CommandData $commandData)
     {
-        return $this->hookManager()->alterResult($names, $result, $commandData);
+        $processDispatcher = new ProcessResultHookDispatcher($this->hookManager(), $names);
+        return $processDispatcher->process($result, $commandData);
     }
 
     /**
@@ -140,7 +153,8 @@ class CommandProcessor
      */
     public function handleResults(OutputInterface $output, $names, $result, CommandData $commandData)
     {
-        $status = $this->hookManager()->determineStatusCode($names, $result);
+        $statusCodeDispatcher = new StatusDeterminerHookDispatcher($this->hookManager(), $names);
+        $status = $statusCodeDispatcher->determineStatusCode($result);
         // If the result is an integer and no separate status code was provided, then use the result as the status and do no output.
         if (is_integer($result) && !isset($status)) {
             return $result;
@@ -148,7 +162,8 @@ class CommandProcessor
         $status = $this->interpretStatusCode($status);
 
         // Get the structured output, the output stream and the formatter
-        $structuredOutput = $this->hookManager()->extractOutput($names, $result);
+        $extractDispatcher = new ExtracterHookDispatcher($this->hookManager(), $names);
+        $structuredOutput = $extractDispatcher->extractOutput($result);
         $output = $this->chooseOutputStream($output, $status);
         if ($status != 0) {
             return $this->writeErrorMessage($output, $status, $structuredOutput, $result);

--- a/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
+++ b/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
@@ -18,22 +18,16 @@ class CommandEventHookDispatcher extends HookDispatcher
      */
     public function callCommandEventHooks(ConsoleCommandEvent $event)
     {
-        $commandEventHooks = $this->getCommandEventHooks();
+        $hooks = [
+            HookManager::PRE_COMMAND_EVENT,
+            HookManager::COMMAND_EVENT,
+            HookManager::POST_COMMAND_EVENT
+        ];
+        $commandEventHooks = $this->getHooks($hooks);
         foreach ($commandEventHooks as $commandEvent) {
             if (is_callable($commandEvent)) {
                 $commandEvent($event);
             }
         }
-    }
-
-    protected function getCommandEventHooks()
-    {
-        return $this->getHooks(
-            [
-                HookManager::PRE_COMMAND_EVENT,
-                HookManager::COMMAND_EVENT,
-                HookManager::POST_COMMAND_EVENT
-            ]
-        );
     }
 }

--- a/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
+++ b/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Call hooks
+ */
+class CommandEventHookDispatcher extends HookDispatcher
+{
+    /**
+     * @param ConsoleCommandEvent $event
+     */
+    public function callCommandEventHooks(ConsoleCommandEvent $event)
+    {
+        $commandEventHooks = $this->getCommandEventHooks();
+        foreach ($commandEventHooks as $commandEvent) {
+            if (is_callable($commandEvent)) {
+                $commandEvent($event);
+            }
+        }
+    }
+
+    protected function getCommandEventHooks()
+    {
+        return $this->getHooks(
+            [
+                HookManager::PRE_COMMAND_EVENT,
+                HookManager::COMMAND_EVENT,
+                HookManager::POST_COMMAND_EVENT
+            ]
+        );
+    }
+}

--- a/src/Hooks/Dispatchers/ExtracterHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ExtracterHookDispatcher.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Consolidation\AnnotatedCommand\Hooks\ExtractOutputInterface;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\OutputDataInterface;
+
+/**
+ * Call hooks
+ */
+class ExtracterHookDispatcher extends HookDispatcher implements ExtractOutputInterface
+{
+    /**
+     * Convert the result object to printable output in
+     * structured form.
+     */
+    public function extractOutput($result)
+    {
+        if ($result instanceof OutputDataInterface) {
+            return $result->getOutputData();
+        }
+
+        $extractors = $this->getOutputExtractors();
+        foreach ($extractors as $extractor) {
+            $structuredOutput = $this->callExtractor($extractor, $result);
+            if (isset($structuredOutput)) {
+                return $structuredOutput;
+            }
+        }
+
+        return $result;
+    }
+
+    protected function callExtractor($extractor, $result)
+    {
+        if ($extractor instanceof ExtractOutputInterface) {
+            return $extractor->extractOutput($result);
+        }
+        if (is_callable($extractor)) {
+            return $extractor($result);
+        }
+    }
+
+    protected function getOutputExtractors()
+    {
+        return $this->getHooks(
+            [
+                HookManager::EXTRACT_OUTPUT,
+            ]
+        );
+    }
+}

--- a/src/Hooks/Dispatchers/ExtracterHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ExtracterHookDispatcher.php
@@ -21,7 +21,10 @@ class ExtracterHookDispatcher extends HookDispatcher implements ExtractOutputInt
             return $result->getOutputData();
         }
 
-        $extractors = $this->getOutputExtractors();
+        $hooks = [
+            HookManager::EXTRACT_OUTPUT,
+        ];
+        $extractors = $this->getHooks($hooks);
         foreach ($extractors as $extractor) {
             $structuredOutput = $this->callExtractor($extractor, $result);
             if (isset($structuredOutput)) {
@@ -40,14 +43,5 @@ class ExtracterHookDispatcher extends HookDispatcher implements ExtractOutputInt
         if (is_callable($extractor)) {
             return $extractor($result);
         }
-    }
-
-    protected function getOutputExtractors()
-    {
-        return $this->getHooks(
-            [
-                HookManager::EXTRACT_OUTPUT,
-            ]
-        );
     }
 }

--- a/src/Hooks/Dispatchers/HookDispatcher.php
+++ b/src/Hooks/Dispatchers/HookDispatcher.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\AnnotationData;
+
+/**
+ * Call hooks
+ */
+class HookDispatcher
+{
+    /** var HookManager */
+    protected $hookManager;
+    protected $names;
+
+    public function __construct(HookManager $hookManager, $names)
+    {
+        $this->hookManager = $hookManager;
+        $this->names = $names;
+    }
+
+    public function getHooks($hooks, $annotationData = null)
+    {
+        return $this->hookManager->getHooks($this->names, $hooks, $annotationData);
+    }
+}

--- a/src/Hooks/Dispatchers/InitializeHookDispatcher.php
+++ b/src/Hooks/Dispatchers/InitializeHookDispatcher.php
@@ -17,7 +17,12 @@ class InitializeHookDispatcher extends HookDispatcher implements InitializeHookI
         InputInterface $input,
         AnnotationData $annotationData
     ) {
-        $providers = $this->getInitializeHooks($annotationData);
+        $hooks = [
+            HookManager::PRE_INITIALIZE,
+            HookManager::INITIALIZE,
+            HookManager::POST_INITIALIZE
+        ];
+        $providers = $this->getHooks($hooks, $annotationData);
         foreach ($providers as $provider) {
             $this->callInitializeHook($provider, $input, $annotationData);
         }
@@ -31,17 +36,5 @@ class InitializeHookDispatcher extends HookDispatcher implements InitializeHookI
         if (is_callable($provider)) {
             return $provider($input, $annotationData);
         }
-    }
-
-    protected function getInitializeHooks(AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            [
-                HookManager::PRE_INITIALIZE,
-                HookManager::INITIALIZE,
-                HookManager::POST_INITIALIZE
-            ],
-            $annotationData
-        );
     }
 }

--- a/src/Hooks/Dispatchers/InitializeHookDispatcher.php
+++ b/src/Hooks/Dispatchers/InitializeHookDispatcher.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\Hooks\InitializeHookInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Call hooks
+ */
+class InitializeHookDispatcher extends HookDispatcher implements InitializeHookInterface
+{
+    public function initialize(
+        InputInterface $input,
+        AnnotationData $annotationData
+    ) {
+        $providers = $this->getInitializeHooks($annotationData);
+        foreach ($providers as $provider) {
+            $this->callInitializeHook($provider, $input, $annotationData);
+        }
+    }
+
+    protected function callInitializeHook($provider, $input, AnnotationData $annotationData)
+    {
+        if ($provider instanceof InitializeHookInterface) {
+            return $provider->initialize($input, $annotationData);
+        }
+        if (is_callable($provider)) {
+            return $provider($input, $annotationData);
+        }
+    }
+
+    protected function getInitializeHooks(AnnotationData $annotationData)
+    {
+        return $this->getHooks(
+            [
+                HookManager::PRE_INITIALIZE,
+                HookManager::INITIALIZE,
+                HookManager::POST_INITIALIZE
+            ],
+            $annotationData
+        );
+    }
+}

--- a/src/Hooks/Dispatchers/InteractHookDispatcher.php
+++ b/src/Hooks/Dispatchers/InteractHookDispatcher.php
@@ -18,7 +18,12 @@ class InteractHookDispatcher extends HookDispatcher
         OutputInterface $output,
         AnnotationData $annotationData
     ) {
-        $interactors = $this->getInteractors($annotationData);
+        $hooks = [
+            HookManager::PRE_INTERACT,
+            HookManager::INTERACT,
+            HookManager::POST_INTERACT
+        ];
+        $interactors = $this->getHooks($hooks, $annotationData);
         foreach ($interactors as $interactor) {
             $this->callInteractor($interactor, $input, $output, $annotationData);
         }
@@ -32,17 +37,5 @@ class InteractHookDispatcher extends HookDispatcher
         if (is_callable($interactor)) {
             return $interactor($input, $output, $annotationData);
         }
-    }
-
-    protected function getInteractors(AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            [
-                HookManager::PRE_INTERACT,
-                HookManager::INTERACT,
-                HookManager::POST_INTERACT
-            ],
-            $annotationData
-        );
     }
 }

--- a/src/Hooks/Dispatchers/InteractHookDispatcher.php
+++ b/src/Hooks/Dispatchers/InteractHookDispatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\Hooks\InteractorInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Call hooks
+ */
+class InteractHookDispatcher extends HookDispatcher
+{
+    public function interact(
+        InputInterface $input,
+        OutputInterface $output,
+        AnnotationData $annotationData
+    ) {
+        $interactors = $this->getInteractors($annotationData);
+        foreach ($interactors as $interactor) {
+            $this->callInteractor($interactor, $input, $output, $annotationData);
+        }
+    }
+
+    protected function callInteractor($interactor, $input, $output, AnnotationData $annotationData)
+    {
+        if ($interactor instanceof InteractorInterface) {
+            return $interactor->interact($input, $output, $annotationData);
+        }
+        if (is_callable($interactor)) {
+            return $interactor($input, $output, $annotationData);
+        }
+    }
+
+    protected function getInteractors(AnnotationData $annotationData)
+    {
+        return $this->getHooks(
+            [
+                HookManager::PRE_INTERACT,
+                HookManager::INTERACT,
+                HookManager::POST_INTERACT
+            ],
+            $annotationData
+        );
+    }
+}

--- a/src/Hooks/Dispatchers/OptionsHookDispatcher.php
+++ b/src/Hooks/Dispatchers/OptionsHookDispatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Symfony\Component\Console\Command\Command;
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\Hooks\OptionHookInterface;
+
+/**
+ * Call hooks
+ */
+class OptionsHookDispatcher extends HookDispatcher implements OptionHookInterface
+{
+    public function getOptions(
+        Command $command,
+        AnnotationData $annotationData
+    ) {
+        $optionHooks = $this->getOptionHooks($annotationData);
+        foreach ($optionHooks as $optionHook) {
+            $this->callOptionHook($optionHook, $command, $annotationData);
+        }
+        $commandInfoList = $this->hookManager->getHookOptionsForCommand($command);
+        $command->optionsHookForHookAnnotations($commandInfoList);
+    }
+
+    protected function callOptionHook($optionHook, $command, AnnotationData $annotationData)
+    {
+        if ($optionHook instanceof OptionHookInterface) {
+            return $optionHook->getOptions($command, $annotationData);
+        }
+        if (is_callable($optionHook)) {
+            return $optionHook($command, $annotationData);
+        }
+    }
+
+    protected function getOptionHooks(AnnotationData $annotationData)
+    {
+        return $this->getHooks(
+            [
+                HookManager::PRE_OPTION_HOOK,
+                HookManager::OPTION_HOOK,
+                HookManager::POST_OPTION_HOOK
+            ],
+            $annotationData
+        );
+    }
+}

--- a/src/Hooks/Dispatchers/OptionsHookDispatcher.php
+++ b/src/Hooks/Dispatchers/OptionsHookDispatcher.php
@@ -3,6 +3,7 @@
 namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
 
 use Symfony\Component\Console\Command\Command;
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Hooks\OptionHookInterface;
@@ -16,12 +17,19 @@ class OptionsHookDispatcher extends HookDispatcher implements OptionHookInterfac
         Command $command,
         AnnotationData $annotationData
     ) {
-        $optionHooks = $this->getOptionHooks($annotationData);
+        $hooks = [
+            HookManager::PRE_OPTION_HOOK,
+            HookManager::OPTION_HOOK,
+            HookManager::POST_OPTION_HOOK
+        ];
+        $optionHooks = $this->getHooks($hooks, $annotationData);
         foreach ($optionHooks as $optionHook) {
             $this->callOptionHook($optionHook, $command, $annotationData);
         }
         $commandInfoList = $this->hookManager->getHookOptionsForCommand($command);
-        $command->optionsHookForHookAnnotations($commandInfoList);
+        if ($command instanceof AnnotatedCommand) {
+            $command->optionsHookForHookAnnotations($commandInfoList);
+        }
     }
 
     protected function callOptionHook($optionHook, $command, AnnotationData $annotationData)
@@ -32,17 +40,5 @@ class OptionsHookDispatcher extends HookDispatcher implements OptionHookInterfac
         if (is_callable($optionHook)) {
             return $optionHook($command, $annotationData);
         }
-    }
-
-    protected function getOptionHooks(AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            [
-                HookManager::PRE_OPTION_HOOK,
-                HookManager::OPTION_HOOK,
-                HookManager::POST_OPTION_HOOK
-            ],
-            $annotationData
-        );
     }
 }

--- a/src/Hooks/Dispatchers/ProcessResultHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ProcessResultHookDispatcher.php
@@ -19,13 +19,18 @@ class ProcessResultHookDispatcher extends HookDispatcher implements ProcessResul
      */
     public function process($result, CommandData $commandData)
     {
-        $processors = $this->getProcessResultHooks($commandData->annotationData());
+        $hooks = [
+            HookManager::PRE_PROCESS_RESULT,
+            HookManager::PROCESS_RESULT,
+            HookManager::POST_PROCESS_RESULT,
+            HookManager::PRE_ALTER_RESULT,
+            HookManager::ALTER_RESULT,
+            HookManager::POST_ALTER_RESULT,
+            HookManager::POST_COMMAND_HOOK,
+        ];
+        $processors = $this->getHooks($hooks, $commandData->annotationData());
         foreach ($processors as $processor) {
             $result = $this->callProcessor($processor, $result, $commandData);
-        }
-        $alterers = $this->getAlterResultHooks($commandData->annotationData());
-        foreach ($alterers as $alterer) {
-            $result = $this->callProcessor($alterer, $result, $commandData);
         }
 
         return $result;
@@ -44,30 +49,5 @@ class ProcessResultHookDispatcher extends HookDispatcher implements ProcessResul
             return $processed;
         }
         return $result;
-    }
-
-    protected function getProcessResultHooks(AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            [
-                HookManager::PRE_PROCESS_RESULT,
-                HookManager::PROCESS_RESULT,
-                HookManager::POST_PROCESS_RESULT
-            ],
-            $annotationData
-        );
-    }
-
-    protected function getAlterResultHooks(AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            [
-                HookManager::PRE_ALTER_RESULT,
-                HookManager::ALTER_RESULT,
-                HookManager::POST_ALTER_RESULT,
-                HookManager::POST_COMMAND_HOOK,
-            ],
-            $annotationData
-        );
     }
 }

--- a/src/Hooks/Dispatchers/ProcessResultHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ProcessResultHookDispatcher.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\Hooks\ProcessResultInterface;
+
+/**
+ * Call hooks
+ */
+class ProcessResultHookDispatcher extends HookDispatcher implements ProcessResultInterface
+{
+    /**
+     * Process result and decide what to do with it.
+     * Allow client to add transformation / interpretation
+     * callbacks.
+     */
+    public function process($result, CommandData $commandData)
+    {
+        $processors = $this->getProcessResultHooks($commandData->annotationData());
+        foreach ($processors as $processor) {
+            $result = $this->callProcessor($processor, $result, $commandData);
+        }
+        $alterers = $this->getAlterResultHooks($commandData->annotationData());
+        foreach ($alterers as $alterer) {
+            $result = $this->callProcessor($alterer, $result, $commandData);
+        }
+
+        return $result;
+    }
+
+    protected function callProcessor($processor, $result, CommandData $commandData)
+    {
+        $processed = null;
+        if ($processor instanceof ProcessResultInterface) {
+            $processed = $processor->process($result, $commandData);
+        }
+        if (is_callable($processor)) {
+            $processed = $processor($result, $commandData);
+        }
+        if (isset($processed)) {
+            return $processed;
+        }
+        return $result;
+    }
+
+    protected function getProcessResultHooks(AnnotationData $annotationData)
+    {
+        return $this->getHooks(
+            [
+                HookManager::PRE_PROCESS_RESULT,
+                HookManager::PROCESS_RESULT,
+                HookManager::POST_PROCESS_RESULT
+            ],
+            $annotationData
+        );
+    }
+
+    protected function getAlterResultHooks(AnnotationData $annotationData)
+    {
+        return $this->getHooks(
+            [
+                HookManager::PRE_ALTER_RESULT,
+                HookManager::ALTER_RESULT,
+                HookManager::POST_ALTER_RESULT,
+                HookManager::POST_COMMAND_HOOK,
+            ],
+            $annotationData
+        );
+    }
+}

--- a/src/Hooks/Dispatchers/StatusDeterminerHookDispatcher.php
+++ b/src/Hooks/Dispatchers/StatusDeterminerHookDispatcher.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Consolidation\AnnotatedCommand\ExitCodeInterface;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\Hooks\StatusDeterminerInterface;
+
+/**
+ * Call hooks
+ */
+class StatusDeterminerHookDispatcher extends HookDispatcher implements StatusDeterminerInterface
+{
+    /**
+     * Call all status determiners, and see if any of them
+     * know how to convert to a status code.
+     */
+    public function determineStatusCode($result)
+    {
+        // If the result (post-processing) is an object that
+        // implements ExitCodeInterface, then we will ask it
+        // to give us the status code.
+        if ($result instanceof ExitCodeInterface) {
+            return $result->getExitCode();
+        }
+
+        // If the result does not implement ExitCodeInterface,
+        // then we'll see if there is a determiner that can
+        // extract a status code from the result.
+        $determiners = $this->getStatusDeterminers();
+        foreach ($determiners as $determiner) {
+            $status = $this->callDeterminer($determiner, $result);
+            if (isset($status)) {
+                return $status;
+            }
+        }
+    }
+
+    protected function callDeterminer($determiner, $result)
+    {
+        if ($determiner instanceof StatusDeterminerInterface) {
+            return $determiner->determineStatusCode($result);
+        }
+        if (is_callable($determiner)) {
+            return $determiner($result);
+        }
+    }
+
+    protected function getStatusDeterminers()
+    {
+        return $this->getHooks(
+            [
+                HookManager::STATUS_DETERMINER,
+            ]
+        );
+    }
+}

--- a/src/Hooks/Dispatchers/StatusDeterminerHookDispatcher.php
+++ b/src/Hooks/Dispatchers/StatusDeterminerHookDispatcher.php
@@ -24,10 +24,13 @@ class StatusDeterminerHookDispatcher extends HookDispatcher implements StatusDet
             return $result->getExitCode();
         }
 
+        $hooks = [
+            HookManager::STATUS_DETERMINER,
+        ];
         // If the result does not implement ExitCodeInterface,
         // then we'll see if there is a determiner that can
         // extract a status code from the result.
-        $determiners = $this->getStatusDeterminers();
+        $determiners = $this->getHooks($hooks);
         foreach ($determiners as $determiner) {
             $status = $this->callDeterminer($determiner, $result);
             if (isset($status)) {
@@ -44,14 +47,5 @@ class StatusDeterminerHookDispatcher extends HookDispatcher implements StatusDet
         if (is_callable($determiner)) {
             return $determiner($result);
         }
-    }
-
-    protected function getStatusDeterminers()
-    {
-        return $this->getHooks(
-            [
-                HookManager::STATUS_DETERMINER,
-            ]
-        );
     }
 }

--- a/src/Hooks/Dispatchers/ValidateHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ValidateHookDispatcher.php
@@ -15,7 +15,14 @@ class ValidateHookDispatcher extends HookDispatcher implements ValidatorInterfac
 {
     public function validate(CommandData $commandData)
     {
-        $validators = $this->getValidators($commandData->annotationData());
+        $hooks = [
+            HookManager::PRE_ARGUMENT_VALIDATOR,
+            HookManager::ARGUMENT_VALIDATOR,
+            HookManager::POST_ARGUMENT_VALIDATOR,
+            HookManager::PRE_COMMAND_HOOK,
+            HookManager::COMMAND_HOOK,
+        ];
+        $validators = $this->getHooks($hooks, $commandData->annotationData());
         foreach ($validators as $validator) {
             $validated = $this->callValidator($validator, $commandData);
             if ($validated === false) {
@@ -35,19 +42,5 @@ class ValidateHookDispatcher extends HookDispatcher implements ValidatorInterfac
         if (is_callable($validator)) {
             return $validator($commandData);
         }
-    }
-
-    protected function getValidators(AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            [
-                HookManager::PRE_ARGUMENT_VALIDATOR,
-                HookManager::ARGUMENT_VALIDATOR,
-                HookManager::POST_ARGUMENT_VALIDATOR,
-                HookManager::PRE_COMMAND_HOOK,
-                HookManager::COMMAND_HOOK,
-            ],
-            $annotationData
-        );
     }
 }

--- a/src/Hooks/Dispatchers/ValidateHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ValidateHookDispatcher.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\CommandError;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\Hooks\ValidatorInterface;
+
+/**
+ * Call hooks
+ */
+class ValidateHookDispatcher extends HookDispatcher implements ValidatorInterface
+{
+    public function validate(CommandData $commandData)
+    {
+        $validators = $this->getValidators($commandData->annotationData());
+        foreach ($validators as $validator) {
+            $validated = $this->callValidator($validator, $commandData);
+            if ($validated === false) {
+                return new CommandError();
+            }
+            if (is_object($validated)) {
+                return $validated;
+            }
+        }
+    }
+
+    protected function callValidator($validator, CommandData $commandData)
+    {
+        if ($validator instanceof ValidatorInterface) {
+            return $validator->validate($commandData);
+        }
+        if (is_callable($validator)) {
+            return $validator($commandData);
+        }
+    }
+
+    protected function getValidators(AnnotationData $annotationData)
+    {
+        return $this->getHooks(
+            [
+                HookManager::PRE_ARGUMENT_VALIDATOR,
+                HookManager::ARGUMENT_VALIDATOR,
+                HookManager::POST_ARGUMENT_VALIDATOR,
+                HookManager::PRE_COMMAND_HOOK,
+                HookManager::COMMAND_HOOK,
+            ],
+            $annotationData
+        );
+    }
+}

--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -14,6 +14,7 @@ use Consolidation\AnnotatedCommand\OutputDataInterface;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandError;
+use Consolidation\AnnotatedCommand\Hooks\Dispatchers\CommandEventHookDispatcher;
 
 /**
  * Manage named callback hooks
@@ -282,30 +283,6 @@ class HookManager implements EventSubscriberInterface
         return $this;
     }
 
-    public function initializeHook(
-        InputInterface $input,
-        $names,
-        AnnotationData $annotationData
-    ) {
-        $providers = $this->getInitializeHooks($names, $annotationData);
-        foreach ($providers as $provider) {
-            $this->callInitializeHook($provider, $input, $annotationData);
-        }
-    }
-
-    public function optionsHook(
-        \Consolidation\AnnotatedCommand\AnnotatedCommand $command,
-        $names,
-        AnnotationData $annotationData
-    ) {
-        $optionHooks = $this->getOptionHooks($names, $annotationData);
-        foreach ($optionHooks as $optionHook) {
-            $this->callOptionHook($optionHook, $command, $annotationData);
-        }
-        $commandInfoList = $this->getHookOptionsForCommand($command);
-        $command->optionsHookForHookAnnotations($commandInfoList);
-    }
-
     public function getHookOptionsForCommand($command)
     {
         $names = $this->addWildcardHooksToNames($command->getNames(), $command->getAnnotationData());
@@ -324,210 +301,6 @@ class HookManager implements EventSubscriberInterface
             }
         }
         return $result;
-    }
-
-    public function interact(
-        InputInterface $input,
-        OutputInterface $output,
-        $names,
-        AnnotationData $annotationData
-    ) {
-        $interactors = $this->getInteractors($names, $annotationData);
-        foreach ($interactors as $interactor) {
-            $this->callInteractor($interactor, $input, $output, $annotationData);
-        }
-    }
-
-    public function validateArguments($names, CommandData $commandData)
-    {
-        $validators = $this->getValidators($names, $commandData->annotationData());
-        foreach ($validators as $validator) {
-            $validated = $this->callValidator($validator, $commandData);
-            if ($validated === false) {
-                return new CommandError();
-            }
-            if (is_object($validated)) {
-                return $validated;
-            }
-        }
-    }
-
-    /**
-     * Process result and decide what to do with it.
-     * Allow client to add transformation / interpretation
-     * callbacks.
-     */
-    public function alterResult($names, $result, CommandData $commandData)
-    {
-        $processors = $this->getProcessResultHooks($names, $commandData->annotationData());
-        foreach ($processors as $processor) {
-            $result = $this->callProcessor($processor, $result, $commandData);
-        }
-        $alterers = $this->getAlterResultHooks($names, $commandData->annotationData());
-        foreach ($alterers as $alterer) {
-            $result = $this->callProcessor($alterer, $result, $commandData);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Call all status determiners, and see if any of them
-     * know how to convert to a status code.
-     */
-    public function determineStatusCode($names, $result)
-    {
-        // If the result (post-processing) is an object that
-        // implements ExitCodeInterface, then we will ask it
-        // to give us the status code.
-        if ($result instanceof ExitCodeInterface) {
-            return $result->getExitCode();
-        }
-
-        // If the result does not implement ExitCodeInterface,
-        // then we'll see if there is a determiner that can
-        // extract a status code from the result.
-        $determiners = $this->getStatusDeterminers($names);
-        foreach ($determiners as $determiner) {
-            $status = $this->callDeterminer($determiner, $result);
-            if (isset($status)) {
-                return $status;
-            }
-        }
-    }
-
-    /**
-     * Convert the result object to printable output in
-     * structured form.
-     */
-    public function extractOutput($names, $result)
-    {
-        if ($result instanceof OutputDataInterface) {
-            return $result->getOutputData();
-        }
-
-        $extractors = $this->getOutputExtractors($names);
-        foreach ($extractors as $extractor) {
-            $structuredOutput = $this->callExtractor($extractor, $result);
-            if (isset($structuredOutput)) {
-                return $structuredOutput;
-            }
-        }
-
-        return $result;
-    }
-
-    protected function getCommandEventHooks($names)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::PRE_COMMAND_EVENT,
-                self::COMMAND_EVENT,
-                self::POST_COMMAND_EVENT
-            ]
-        );
-    }
-
-    protected function getInitializeHooks($names, AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::PRE_INITIALIZE,
-                self::INITIALIZE,
-                self::POST_INITIALIZE
-            ],
-            $annotationData
-        );
-    }
-
-    protected function getOptionHooks($names, AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::PRE_OPTION_HOOK,
-                self::OPTION_HOOK,
-                self::POST_OPTION_HOOK
-            ],
-            $annotationData
-        );
-    }
-
-    protected function getInteractors($names, AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::PRE_INTERACT,
-                self::INTERACT,
-                self::POST_INTERACT
-            ],
-            $annotationData
-        );
-    }
-
-    protected function getValidators($names, AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::PRE_ARGUMENT_VALIDATOR,
-                self::ARGUMENT_VALIDATOR,
-                self::POST_ARGUMENT_VALIDATOR,
-                self::PRE_COMMAND_HOOK,
-                self::COMMAND_HOOK,
-            ],
-            $annotationData
-        );
-    }
-
-    protected function getProcessResultHooks($names, AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::PRE_PROCESS_RESULT,
-                self::PROCESS_RESULT,
-                self::POST_PROCESS_RESULT
-            ],
-            $annotationData
-        );
-    }
-
-    protected function getAlterResultHooks($names, AnnotationData $annotationData)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::PRE_ALTER_RESULT,
-                self::ALTER_RESULT,
-                self::POST_ALTER_RESULT,
-                self::POST_COMMAND_HOOK,
-            ],
-            $annotationData
-        );
-    }
-
-    protected function getStatusDeterminers($names)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::STATUS_DETERMINER,
-            ]
-        );
-    }
-
-    protected function getOutputExtractors($names)
-    {
-        return $this->getHooks(
-            $names,
-            [
-                self::EXTRACT_OUTPUT,
-            ]
-        );
     }
 
     /**
@@ -592,103 +365,22 @@ class HookManager implements EventSubscriberInterface
         return [];
     }
 
-    protected function callInitializeHook($provider, $input, AnnotationData $annotationData)
-    {
-        if ($provider instanceof InitializeHookInterface) {
-            return $provider->initialize($input, $annotationData);
-        }
-        if (is_callable($provider)) {
-            return $provider($input, $annotationData);
-        }
-    }
-
-    protected function callOptionHook($optionHook, $command, AnnotationData $annotationData)
-    {
-        if ($optionHook instanceof OptionHookInterface) {
-            return $optionHook->getOptions($command, $annotationData);
-        }
-        if (is_callable($optionHook)) {
-            return $optionHook($command, $annotationData);
-        }
-    }
-
-    protected function callInteractor($interactor, $input, $output, AnnotationData $annotationData)
-    {
-        if ($interactor instanceof InteractorInterface) {
-            return $interactor->interact($input, $output, $annotationData);
-        }
-        if (is_callable($interactor)) {
-            return $interactor($input, $output, $annotationData);
-        }
-    }
-
-    protected function callValidator($validator, CommandData $commandData)
-    {
-        if ($validator instanceof ValidatorInterface) {
-            return $validator->validate($commandData);
-        }
-        if (is_callable($validator)) {
-            return $validator($commandData);
-        }
-    }
-
-    protected function callProcessor($processor, $result, CommandData $commandData)
-    {
-        $processed = null;
-        if ($processor instanceof ProcessResultInterface) {
-            $processed = $processor->process($result, $commandData);
-        }
-        if (is_callable($processor)) {
-            $processed = $processor($result, $commandData);
-        }
-        if (isset($processed)) {
-            return $processed;
-        }
-        return $result;
-    }
-
-    protected function callDeterminer($determiner, $result)
-    {
-        if ($determiner instanceof StatusDeterminerInterface) {
-            return $determiner->determineStatusCode($result);
-        }
-        if (is_callable($determiner)) {
-            return $determiner($result);
-        }
-    }
-
-    protected function callExtractor($extractor, $result)
-    {
-        if ($extractor instanceof ExtractOutputInterface) {
-            return $extractor->extractOutput($result);
-        }
-        if (is_callable($extractor)) {
-            return $extractor($result);
-        }
-    }
-
     /**
+     * Call the command event hooks.
+     *
+     * TODO: This should be moved to CommandEventHookDispatcher, which
+     * should become the class that implements EventSubscriberInterface.
+     * This change would break all clients, though, so postpone until next
+     * major release.
+     *
      * @param ConsoleCommandEvent $event
      */
     public function callCommandEventHooks(ConsoleCommandEvent $event)
     {
         /* @var Command $command */
         $command = $event->getCommand();
-        $names = [$command->getName()];
-        $commandEventHooks = $this->getCommandEventHooks($names);
-        foreach ($commandEventHooks as $commandEvent) {
-            if (is_callable($commandEvent)) {
-                $commandEvent($event);
-            }
-        }
-    }
-
-    public function findAndAddHookOptions($command)
-    {
-        if (!$command instanceof \Consolidation\AnnotatedCommand\AnnotatedCommand) {
-            return;
-        }
-        $command->optionsHook();
+        $dispatcher = new CommandEventHookDispatcher($this, [$command->getName()]);
+        $dispatcher->callCommandEventHooks($event);
     }
 
     /**


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Improves code quality
- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
The hook manager class was too large; removed the responsibility of hook dispatching from it for better maintainability.

Note that this PR removes public methods from the HookManager; however, this change is not considered to be a significant backwards-compatibility break, as no client should call these methods.