### PR TITLE
Ensure that the default value of options are correctly cached.

### DIFF
--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -251,7 +251,6 @@ class CommandInfo
             'parameters' => [],
             'arguments' => [],
             'options' => [],
-            'input_options' => [],
             'mtime' => 0,
         ];
     }

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -102,11 +102,14 @@ class CommandInfo
     {
         $this->reflection = new \ReflectionMethod($classNameOrInstance, $methodName);
         $this->methodName = $methodName;
+        $this->arguments = new DefaultsWithDescriptions();
+        $this->options = new DefaultsWithDescriptions();
 
         // If the cache came from a newer version, ignore it and
         // regenerate the cached information.
-        if (!empty($cache) && static::isValidSerializedData($cache) && !$this->cachedFileIsModified($cache)) {
-            $this->constructFromCache($cache);
+        if (!empty($cache) && CommandInfoDeserializer::isValidSerializedData($cache) && !$this->cachedFileIsModified($cache)) {
+            $deserializer = new CommandInfoDeserializer();
+            $deserializer->constructFromCache($this, $cache);
             $this->docBlockIsParsed = true;
         } else {
             $this->constructFromClassAndMethod($classNameOrInstance, $methodName);
@@ -121,32 +124,7 @@ class CommandInfo
     public static function deserialize($cache)
     {
         $cache = (array)$cache;
-
-        $className = $cache['class'];
-        $methodName = $cache['method_name'];
-
-        return new self($className, $methodName, $cache);
-    }
-
-    protected static function cachedMethodExists($cache)
-    {
-        $cache = (array)$cache;
-
-        $className = $cache['class'];
-        $methodName = $cache['method_name'];
-
-        return method_exists($className, $methodName);
-    }
-
-    public static function isValidSerializedData($cache)
-    {
-        return
-            isset($cache['schema']) &&
-            isset($cache['method_name']) &&
-            isset($cache['mtime']) &&
-            ($cache['schema'] > 0) &&
-            ($cache['schema'] <= self::SERIALIZATION_SCHEMA_VERSION) &&
-            self::cachedMethodExists($cache);
+        return new self($cache['class'], $cache['method_name'], $cache);
     }
 
     public function cachedFileIsModified($cache)
@@ -163,96 +141,6 @@ class CommandInfo
         $this->name = $this->convertName($methodName);
         $this->options = new DefaultsWithDescriptions($this->determineOptionsFromParameters(), false);
         $this->arguments = $this->determineAgumentClassifications();
-    }
-
-    protected function constructFromCache($info_array)
-    {
-        $info_array += $this->defaultSerializationData();
-
-        $this->name = $info_array['name'];
-        $this->methodName = $info_array['method_name'];
-        $this->otherAnnotations = new AnnotationData((array) $info_array['annotations']);
-        $this->arguments = new DefaultsWithDescriptions();
-        $this->options = new DefaultsWithDescriptions();
-        $this->aliases = $info_array['aliases'];
-        $this->help = $info_array['help'];
-        $this->description = $info_array['description'];
-        $this->exampleUsage = $info_array['example_usages'];
-        $this->returnType = $info_array['return_type'];
-
-        $this->constructDefaultsWithDescriptions($this->arguments, (array)$info_array['arguments']);
-        $this->constructDefaultsWithDescriptions($this->options, (array)$info_array['options']);
-    }
-
-    protected function constructDefaultsWithDescriptions(DefaultsWithDescriptions $defaults, $data)
-    {
-        foreach ($data as $key => $info) {
-            $info = (array)$info;
-            $defaults->add($key, $info['description']);
-            if (array_key_exists('default', $info)) {
-                $defaults->setDefaultValue($key, $info['default']);
-            }
-        }
-    }
-
-    public function serialize()
-    {
-        $path = $this->reflection->getFileName();
-
-        $info = [
-            'schema' => self::SERIALIZATION_SCHEMA_VERSION,
-            'class' => $this->reflection->getDeclaringClass()->getName(),
-            'method_name' => $this->getMethodName(),
-            'name' => $this->getName(),
-            'description' => $this->getDescription(),
-            'help' => $this->getHelp(),
-            'aliases' => $this->getAliases(),
-            'annotations' => $this->getAnnotations()->getArrayCopy(),
-            // Todo: Test This.
-            'topics' => $this->getTopics(),
-            'example_usages' => $this->getExampleUsages(),
-            'return_type' => $this->getReturnType(),
-            'mtime' => filemtime($path),
-        ] + $this->defaultSerializationData();
-        $info['arguments'] = $this->serializeDefaultsWithDescriptions($this->arguments());
-        $info['options'] = $this->serializeDefaultsWithDescriptions($this->options());
-
-        return $info;
-    }
-
-    protected function serializeDefaultsWithDescriptions(DefaultsWithDescriptions $defaults)
-    {
-        $result = [];
-        foreach ($defaults->getValues() as $key => $val) {
-            $result[$key] = [
-                'description' => $defaults->getDescription($key),
-            ];
-            if ($defaults->hasDefault($key)) {
-                $result[$key]['default'] = $val;
-            }
-        }
-        return $result;
-    }
-
-    /**
-     * Default data for serialization.
-     * @return array
-     */
-    protected function defaultSerializationData()
-    {
-        return [
-            'description' => '',
-            'help' => '',
-            'aliases' => [],
-            'annotations' => [],
-            'topics' => [],
-            'example_usages' => [],
-            'return_type' => [],
-            'parameters' => [],
-            'arguments' => [],
-            'options' => [],
-            'mtime' => 0,
-        ];
     }
 
     /**
@@ -313,6 +201,15 @@ class CommandInfo
     }
 
     /**
+     * Replace the annotation data.
+     */
+    public function replaceRawAnnotations($annotationData)
+    {
+        $this->otherAnnotations = new AnnotationData((array) $annotationData);
+        return $this;
+    }
+
+    /**
      * Get any annotations included in the docblock comment,
      * also including default values such as @command.  We add
      * in the default @command annotation late, and only in a
@@ -324,14 +221,16 @@ class CommandInfo
      */
     public function getAnnotations()
     {
-        // Also provide the path to the commandfile that
-        // these annotations were pulled from.
+        // Also provide the path to the commandfile that these annotations
+        // were pulled from and the classname of that file.
         $path = $this->reflection->getFileName();
+        $className = $this->reflection->getDeclaringClass()->getName();
         return new AnnotationData(
             $this->getRawAnnotations()->getArrayCopy() +
             [
                 'command' => $this->getName(),
                 '_path' => $path,
+                '_classname' => $className,
             ]
         );
     }
@@ -468,6 +367,15 @@ class CommandInfo
     public function setExampleUsage($usage, $description)
     {
         $this->exampleUsage[$usage] = $description;
+        return $this;
+    }
+
+    /**
+     * Overwrite all example usages
+     */
+    public function replaceExampleUsages($usages)
+    {
+        $this->exampleUsage = $usages;
         return $this;
     }
 

--- a/src/Parser/CommandInfoDeserializer.php
+++ b/src/Parser/CommandInfoDeserializer.php
@@ -1,0 +1,86 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Parser;
+
+use Symfony\Component\Console\Input\InputOption;
+use Consolidation\AnnotatedCommand\Parser\Internal\CommandDocBlockParser;
+use Consolidation\AnnotatedCommand\Parser\Internal\CommandDocBlockParserFactory;
+use Consolidation\AnnotatedCommand\AnnotationData;
+
+/**
+ * Deserialize a CommandInfo object
+ */
+class CommandInfoDeserializer
+{
+    // TODO: in a future version, move CommandInfo::deserialize here
+    public function deserialize($data)
+    {
+        return CommandInfo::deserialize((array)$data);
+    }
+
+    protected static function cachedMethodExists($cache)
+    {
+        return method_exists($cache['class'], $cache['method_name']);
+    }
+
+    public static function isValidSerializedData($cache)
+    {
+        return
+            isset($cache['schema']) &&
+            isset($cache['method_name']) &&
+            isset($cache['mtime']) &&
+            ($cache['schema'] > 0) &&
+            ($cache['schema'] <= CommandInfo::SERIALIZATION_SCHEMA_VERSION) &&
+            self::cachedMethodExists($cache);
+    }
+
+    public function constructFromCache(CommandInfo $commandInfo, $info_array)
+    {
+        $info_array += $this->defaultSerializationData();
+
+        $commandInfo
+            ->setName($info_array['name'])
+            ->replaceRawAnnotations($info_array['annotations'])
+            ->setAliases($info_array['aliases'])
+            ->setHelp($info_array['help'])
+            ->setDescription($info_array['description'])
+            ->replaceExampleUsages($info_array['example_usages'])
+            ->setReturnType($info_array['return_type'])
+            ;
+
+        $this->constructDefaultsWithDescriptions($commandInfo->arguments(), (array)$info_array['arguments']);
+        $this->constructDefaultsWithDescriptions($commandInfo->options(), (array)$info_array['options']);
+    }
+
+    protected function constructDefaultsWithDescriptions(DefaultsWithDescriptions $defaults, $data)
+    {
+        foreach ($data as $key => $info) {
+            $info = (array)$info;
+            $defaults->add($key, $info['description']);
+            if (array_key_exists('default', $info)) {
+                $defaults->setDefaultValue($key, $info['default']);
+            }
+        }
+    }
+
+
+    /**
+     * Default data. Everything should be provided during serialization;
+     * this is just as a fallback for unusual circumstances.
+     * @return array
+     */
+    protected function defaultSerializationData()
+    {
+        return [
+            'description' => '',
+            'help' => '',
+            'aliases' => [],
+            'annotations' => [],
+            'example_usages' => [],
+            'return_type' => [],
+            'parameters' => [],
+            'arguments' => [],
+            'options' => [],
+            'mtime' => 0,
+        ];
+    }
+}

--- a/src/Parser/CommandInfoSerializer.php
+++ b/src/Parser/CommandInfoSerializer.php
@@ -1,0 +1,52 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Parser;
+
+use Symfony\Component\Console\Input\InputOption;
+use Consolidation\AnnotatedCommand\Parser\Internal\CommandDocBlockParser;
+use Consolidation\AnnotatedCommand\Parser\Internal\CommandDocBlockParserFactory;
+use Consolidation\AnnotatedCommand\AnnotationData;
+
+/**
+ * Serialize a CommandInfo object
+ */
+class CommandInfoSerializer
+{
+    public function serialize(CommandInfo $commandInfo)
+    {
+        $allAnnotations = $commandInfo->getAnnotations();
+        $path = $allAnnotations['_path'];
+        $className = $allAnnotations['_classname'];
+
+        $info = [
+            'schema' => CommandInfo::SERIALIZATION_SCHEMA_VERSION,
+            'class' => $className,
+            'method_name' => $commandInfo->getMethodName(),
+            'name' => $commandInfo->getName(),
+            'description' => $commandInfo->getDescription(),
+            'help' => $commandInfo->getHelp(),
+            'aliases' => $commandInfo->getAliases(),
+            'annotations' => $commandInfo->getRawAnnotations()->getArrayCopy(),
+            'example_usages' => $commandInfo->getExampleUsages(),
+            'return_type' => $commandInfo->getReturnType(),
+            'mtime' => filemtime($path),
+        ];
+        $info['arguments'] = $this->serializeDefaultsWithDescriptions($commandInfo->arguments());
+        $info['options'] = $this->serializeDefaultsWithDescriptions($commandInfo->options());
+
+        return $info;
+    }
+
+    protected function serializeDefaultsWithDescriptions(DefaultsWithDescriptions $defaults)
+    {
+        $result = [];
+        foreach ($defaults->getValues() as $key => $val) {
+            $result[$key] = [
+                'description' => $defaults->getDescription($key),
+            ];
+            if ($defaults->hasDefault($key)) {
+                $result[$key]['default'] = $val;
+            }
+        }
+        return $result;
+    }
+}

--- a/src/Parser/DefaultsWithDescriptions.php
+++ b/src/Parser/DefaultsWithDescriptions.php
@@ -32,7 +32,7 @@ class DefaultsWithDescriptions
     public function __construct($values = [], $defaultDefault = null)
     {
         $this->values = $values;
-        $this->hasDefault = [];
+        $this->hasDefault = array_filter($this->values);
         $this->descriptions = [];
         $this->defaultDefault = $defaultDefault;
     }

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -143,7 +143,7 @@ class ExampleCommandFile
      *   Add two plus two and then negate.
      * @custom
      */
-    public function testArithmatic($one, $two, $options = ['negate' => false])
+    public function testArithmatic($one, $two = 2, $options = ['negate' => false, 'unused' => 'bob'])
     {
         $result = $one + $two;
         if ($options['negate']) {

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -578,7 +578,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $annotationData = $commandInfo->getRawAnnotations();
         $this->assertEquals('addmycommandname', implode(',', $annotationData->keys()));
         $annotationData = $commandInfo->getAnnotations();
-        $this->assertEquals('addmycommandname,command,_path', implode(',', $annotationData->keys()));
+        $this->assertEquals('addmycommandname,command,_path,_classname', implode(',', $annotationData->keys()));
 
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
 
@@ -588,7 +588,6 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $input = new StringInput('alter:me-too');
         $this->assertRunCommandViaApplicationEquals($command, $input, 'fantabulous from alter:me-too');
     }
-
 
     function testHookedCommandWithHookAddedLater()
     {

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -123,7 +123,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertEquals('This is the test:arithmatic command', $command->getDescription());
         $this->assertEquals("This command will add one and two. If the --negate flag\nis provided, then the result is negated.", $command->getHelp());
         $this->assertEquals('arithmatic', implode(',', $command->getAliases()));
-        $this->assertEquals('test:arithmatic [--negate] [--] <one> <two>', $command->getSynopsis());
+        $this->assertEquals('test:arithmatic [--negate] [--unused [UNUSED]] [--] <one> [<two>]', $command->getSynopsis());
         $this->assertEquals('test:arithmatic 2 2 --negate', implode(',', $command->getUsages()));
 
         $input = new StringInput('arithmatic 2 3 --negate');

--- a/tests/testCommandInfo.php
+++ b/tests/testCommandInfo.php
@@ -56,8 +56,16 @@ class CommandInfoTests extends \PHPUnit_Framework_TestCase
             $commandInfo->arguments()->getDescription('two')
         );
         $this->assertEquals(
+            '2',
+            $commandInfo->arguments()->get('two')
+        );
+        $this->assertEquals(
             'Whether or not the result should be negated.',
             $commandInfo->options()->getDescription('negate')
+        );
+        $this->assertEquals(
+            'bob',
+            $commandInfo->options()->get('unused')
         );
     }
 

--- a/tests/testCommandInfo.php
+++ b/tests/testCommandInfo.php
@@ -2,6 +2,8 @@
 namespace Consolidation\AnnotatedCommand;
 
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Consolidation\AnnotatedCommand\Parser\CommandInfoSerializer;
+use Consolidation\AnnotatedCommand\Parser\CommandInfoDeserializer;
 
 class CommandInfoTests extends \PHPUnit_Framework_TestCase
 {
@@ -25,9 +27,12 @@ class CommandInfoTests extends \PHPUnit_Framework_TestCase
         $commandInfo = CommandInfo::create('\Consolidation\TestUtils\ExampleCommandFile', 'testArithmatic');
         $this->assertCommandInfoIsAsExpected($commandInfo);
 
-        $serialized = $commandInfo->serialize();
+        $serializer = new CommandInfoSerializer();
+        $serialized = $serializer->serialize($commandInfo);
 
-        $deserializedCommandInfo = CommandInfo::deserialize($serialized);
+        $deserializer = new CommandInfoDeserializer();
+
+        $deserializedCommandInfo = $deserializer->deserialize($serialized);
         $this->assertCommandInfoIsAsExpected($deserializedCommandInfo);
     }
 


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Command options were losing their default values after being cached, and restored from the cache.