### PR TITLE
Ensure that placeholder entries are written into the commandfile cache.

### DIFF
--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -168,11 +168,8 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         }
         $cache_data = [];
         $serializer = new CommandInfoSerializer();
-        $includeAllPublicMethods = $this->getIncludeAllPublicMethods();
         foreach ($commandInfoList as $i => $commandInfo) {
-            if (static::isCommandOrHookMethod($commandInfo, $includeAllPublicMethods)) {
-                $cache_data[$i] = $serializer->serialize($commandInfo);
-            }
+            $cache_data[$i] = $serializer->serialize($commandInfo);
         }
         $className = get_class($commandFileInstance);
         $this->getDataStore()->set($className, $cache_data);
@@ -257,9 +254,10 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         foreach ($commandMethodNames as $commandMethodName) {
             if (!array_key_exists($commandMethodName, $cachedCommandInfoList)) {
                 $commandInfo = CommandInfo::create($classNameOrInstance, $commandMethodName);
-                if (static::isCommandOrHookMethod($commandInfo, $this->getIncludeAllPublicMethods())) {
-                    $commandInfoList[$commandMethodName] =  $commandInfo;
+                if (!static::isCommandOrHookMethod($commandInfo, $this->getIncludeAllPublicMethods())) {
+                    $commandInfo->invalidate();
                 }
+                $commandInfoList[$commandMethodName] =  $commandInfo;
             }
         }
 

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -175,6 +175,28 @@ class CommandInfo
         return $this;
     }
 
+    /**
+     * Return whether or not this method represents a valid command
+     * or hook.
+     */
+    public function valid()
+    {
+        return !empty($this->name);
+    }
+
+    /**
+     * If higher-level code decides that this CommandInfo is not interesting
+     * or useful (if it is not a command method or a hook method), then
+     * we will mark it as invalid to prevent it from being created as a command.
+     * We still cache a placeholder record for invalid methods, so that we
+     * do not need to re-parse the method again later simply to determine that
+     * it is invalid.
+     */
+    public function invalidate()
+    {
+        $this->name = '';
+    }
+
     public function getReturnType()
     {
         $this->parseDocBlock();

--- a/src/Parser/CommandInfoDeserializer.php
+++ b/src/Parser/CommandInfoDeserializer.php
@@ -71,6 +71,7 @@ class CommandInfoDeserializer
     protected function defaultSerializationData()
     {
         return [
+            'name' => '',
             'description' => '',
             'help' => '',
             'aliases' => [],

--- a/src/Parser/CommandInfoSerializer.php
+++ b/src/Parser/CommandInfoSerializer.php
@@ -17,21 +17,28 @@ class CommandInfoSerializer
         $path = $allAnnotations['_path'];
         $className = $allAnnotations['_classname'];
 
+        // Include the minimum information for command info (including placeholder records)
         $info = [
             'schema' => CommandInfo::SERIALIZATION_SCHEMA_VERSION,
             'class' => $className,
             'method_name' => $commandInfo->getMethodName(),
-            'name' => $commandInfo->getName(),
-            'description' => $commandInfo->getDescription(),
-            'help' => $commandInfo->getHelp(),
-            'aliases' => $commandInfo->getAliases(),
-            'annotations' => $commandInfo->getRawAnnotations()->getArrayCopy(),
-            'example_usages' => $commandInfo->getExampleUsages(),
-            'return_type' => $commandInfo->getReturnType(),
             'mtime' => filemtime($path),
         ];
-        $info['arguments'] = $this->serializeDefaultsWithDescriptions($commandInfo->arguments());
-        $info['options'] = $this->serializeDefaultsWithDescriptions($commandInfo->options());
+
+        // If this is a valid method / hook, then add more information.
+        if ($commandInfo->valid()) {
+            $info += [
+                'name' => $commandInfo->getName(),
+                'description' => $commandInfo->getDescription(),
+                'help' => $commandInfo->getHelp(),
+                'aliases' => $commandInfo->getAliases(),
+                'annotations' => $commandInfo->getRawAnnotations()->getArrayCopy(),
+                'example_usages' => $commandInfo->getExampleUsages(),
+                'return_type' => $commandInfo->getReturnType(),
+            ];
+            $info['arguments'] = $this->serializeDefaultsWithDescriptions($commandInfo->arguments());
+            $info['options'] = $this->serializeDefaultsWithDescriptions($commandInfo->options());
+        }
 
         return $info;
     }


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Description
Previous release optimized the commandfile cache, removing unneeded entries for methods that were not hooks or commands. Unfortunately, this added a significant amount of overhead to the restore-from-cache code path, as the un-cached methods needed to be parsed again, just to determine that they are not hooks or commands.

To fix this, we store a placeholder entry in the cache indicating that the method is invalid.