### PR TITLE
Ensure that the help text description never wraps

### DIFF
--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -319,7 +319,7 @@ class CommandInfo
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = str_replace("\n", ' ', $description);
         return $this;
     }
 

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -422,6 +422,9 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
 
         $input = new StringInput('test:hook bar');
         $this->assertRunCommandViaApplicationEquals($command, $input, '<[bar]>');
+
+        $input = new StringInput('list --raw');
+        $this->assertRunCommandViaApplicationContains($command, $input, ['This command wraps its parameter in []; its alter hook then wraps the result in .']);
     }
 
     function testPostCommandCalledAfterCommand()


### PR DESCRIPTION
This is important for 'list --format=raw'.

### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
`list --format=raw` contains unnecessary / incorrect line breaks if the help description contains any line breaks. This PR ensures that will never happen.