### PR TITLE
Adding command-event hook.

### DIFF
--- a/src/Hooks/CommandEventHookInterface.php
+++ b/src/Hooks/CommandEventHookInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Hooks;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ *
+ *
+ * @see HookManager::addCommandEventHook()
+ */
+interface CommandEventHookInterface
+{
+    // @todo replace with correct arguments. see http://symfony.com/doc/current/components/console/events.html
+    public function initialize(ConsoleCommandEvent $event);
+}

--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -122,6 +122,19 @@ class HookManager implements EventSubscriberInterface
     /**
      * Add an configuration provider hook
      *
+     * @param type CommandEventHookInterface $commandEventHook
+     * @param type $name The name of the command to hook
+     *   ('*' for all)
+     */
+    public function addCommandEventHook(CommandEventHookInterface $commandEventHook, $name = '*')
+    {
+        $this->hooks[$name][self::COMMAND_EVENT][] = $commandEventHook;
+        return $this;
+    }
+
+    /**
+     * Add an configuration provider hook
+     *
      * @param type InitializeHookInterface $provider
      * @param type $name The name of the command to hook
      *   ('*' for all)


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Add a the ability to hook into Symfony's command event.

### Description
E.g.,
```
  /**
   * @hook command-event tests:behat
   */
```
