### PR TITLE
Automatically disable wordwrap when the terminal is not connected to STDOUT

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   - echo extension=php_pdo_sqlite.dll >> php.ini
   - echo extension=php_pgsql.dll >> php.ini
   - echo extension=php_gd2.dll >> php.ini
-  - SET PATH=C:\tools\php;%PATH%
+  - SET PATH=C:\tools\php70;%PATH%
   #Install Composer
   - cd %APPVEYOR_BUILD_FOLDER%
   #- appveyor DownloadFile https://getcomposer.org/composer.phar

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
   #Install PHP per https://blog.wyrihaximus.net/2016/11/running-php-unit-tests-on-windows-using-appveyor-and-chocolatey/
   - ps: appveyor-retry cinst --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]','')
-  - cd c:\tools\php
+  - cd c:\tools\php70
   - copy php.ini-production php.ini
 
   - echo extension_dir=ext >> php.ini

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "consolidation/output-formatters": "^3.1.5",
+        "consolidation/output-formatters": "^3.1.10",
         "psr/log": "^1",
         "symfony/console": "^2.8|~3",
         "symfony/event-dispatcher": "^2.5|^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7ce9382007faad2be0ddde1399067a2",
+    "content-hash": "a53b5b320f8846d37bb89edddd116271",
     "packages": [
         {
             "name": "consolidation/output-formatters",
-            "version": "3.1.8",
+            "version": "3.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "0b50ba1134d581fd55376f3e21508dab009ced47"
+                "reference": "3872f19517bfc9da0e14c9e5b6fe0f8c7439ea3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/0b50ba1134d581fd55376f3e21508dab009ced47",
-                "reference": "0b50ba1134d581fd55376f3e21508dab009ced47",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/3872f19517bfc9da0e14c9e5b6fe0f8c7439ea3a",
+                "reference": "3872f19517bfc9da0e14c9e5b6fe0f8c7439ea3a",
                 "shasum": ""
             },
             "require": {
@@ -34,7 +34,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
@@ -53,7 +53,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2017-03-01T20:54:45+00:00"
+            "time": "2017-06-06T19:08:54+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/src/Options/PrepareTerminalWidthOption.php
+++ b/src/Options/PrepareTerminalWidthOption.php
@@ -19,14 +19,28 @@ class PrepareTerminalWidthOption implements PrepareFormatter
     /** var int */
     protected $minWidth = 0;
 
+    /* var boolean */
+    protected $shouldWrap = true;
+
     public function __construct($defaultWidth = 0)
     {
         $this->defaultWidth = $defaultWidth;
+
+        // If STDOUT is not attached to a terminal, then disable
+        // automatic width detection.
+        if (function_exists('posix_isatty') && !posix_isatty(STDOUT)) {
+            $this->shouldWrap = false;
+        }
     }
 
     public function setApplication(Application $application)
     {
         $this->application = $application;
+    }
+
+    public function enableWrap($shouldWrap)
+    {
+        $this->shouldWrap = $shouldWrap;
     }
 
     public function prepare(CommandData $commandData, FormatterOptions $options)
@@ -45,7 +59,7 @@ class PrepareTerminalWidthOption implements PrepareFormatter
 
     protected function getTerminalWidth()
     {
-        if (!$this->application) {
+        if (!$this->application || !$this->shouldWrap) {
             return 0;
         }
 

--- a/src/Options/PrepareTerminalWidthOption.php
+++ b/src/Options/PrepareTerminalWidthOption.php
@@ -10,6 +10,8 @@ class PrepareTerminalWidthOption implements PrepareFormatter
     /** var Application */
     protected $application;
 
+    protected $terminal;
+
     /** var int */
     protected $defaultWidth;
 
@@ -38,6 +40,19 @@ class PrepareTerminalWidthOption implements PrepareFormatter
         $this->application = $application;
     }
 
+    public function setTerminal($terminal)
+    {
+        $this->terminal = $terminal;
+    }
+
+    public function getTerminal()
+    {
+        if (!$this->terminal && class_exists('\Symfony\Component\Console\Terminal')) {
+            $this->terminal = new \Symfony\Component\Console\Terminal();
+        }
+        return $this->terminal;
+    }
+
     public function enableWrap($shouldWrap)
     {
         $this->shouldWrap = $shouldWrap;
@@ -59,10 +74,24 @@ class PrepareTerminalWidthOption implements PrepareFormatter
 
     protected function getTerminalWidth()
     {
-        if (!$this->application || !$this->shouldWrap) {
+        // Don't wrap if wrapping has been disabled.
+        if (!$this->shouldWrap) {
             return 0;
         }
 
+        $terminal = $this->getTerminal();
+        if ($terminal) {
+            return $terminal->getWidth();
+        }
+
+        return $this->getTerminalWidthViaApplication();
+    }
+
+    protected function getTerminalWidthViaApplication()
+    {
+        if (!$this->application) {
+            return 0;
+        }
         $dimensions = $this->application->getTerminalDimensions();
         if ($dimensions[0] == null) {
             return 0;

--- a/tests/src/TestTerminal.php
+++ b/tests/src/TestTerminal.php
@@ -1,0 +1,22 @@
+<?php
+namespace Consolidation\TestUtils;
+
+class TestTerminal
+{
+    protected $width = 0;
+
+    public function __construct($width)
+    {
+        $this->width = $width;
+    }
+
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    public function setWidth($width)
+    {
+        $this->width = $width;
+    }
+}

--- a/tests/testFullStack.php
+++ b/tests/testFullStack.php
@@ -13,6 +13,7 @@ use Consolidation\AnnotatedCommand\Hooks\ValidatorInterface;
 use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Consolidation\OutputFormatters\FormatterManager;
+use Consolidation\TestUtils\TestTerminal;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -96,6 +97,8 @@ class FullStackTests extends \PHPUnit_Framework_TestCase
         $terminalWidthOption = new PrepareTerminalWidthOption();
         $terminalWidthOption->enableWrap(true);
         $terminalWidthOption->setApplication($this->application);
+        $testTerminal = new TestTerminal(0);
+        $terminalWidthOption->setTerminal($testTerminal);
         $commandProcessor = new CommandProcessor($hookManager);
         $commandProcessor->setFormatterManager($formatter);
         $commandProcessor->addPrepareFormatter($terminalWidthOption);
@@ -250,20 +253,21 @@ EOT;
         $this->assertRunCommandViaApplicationEquals('example:wrap', $expectedUnwrappedOutput);
 
         $expectedWrappedOutput = <<<EOT
- ------------------- --------------------
-  First               Second
- ------------------- --------------------
-  This is a really    This is the second
-  long cell that      column of the same
-  contains a lot of   table. It is also
-  data. When it is    very long, and
-  rendered, it        should be wrapped
-  should be wrapped   across multiple
-  across multiple     lines, just like
-  lines.              the first column.
- ------------------- --------------------
+ ------------------ --------------------
+  First              Second
+ ------------------ --------------------
+  This is a really   This is the second
+  long cell that     column of the same
+  contains a lot     table. It is also
+  of data. When it   very long, and
+  is rendered, it    should be wrapped
+  should be          across multiple
+  wrapped across     lines, just like
+  multiple lines.    the first column.
+ ------------------ --------------------
 EOT;
         $this->application->setWidthAndHeight(42, 24);
+        $testTerminal->setWidth(42);
         $this->assertRunCommandViaApplicationEquals('example:wrap', $expectedWrappedOutput);
     }
 

--- a/tests/testFullStack.php
+++ b/tests/testFullStack.php
@@ -94,6 +94,7 @@ class FullStackTests extends \PHPUnit_Framework_TestCase
         $formatter->addDefaultSimplifiers();
         $hookManager = new HookManager();
         $terminalWidthOption = new PrepareTerminalWidthOption();
+        $terminalWidthOption->enableWrap(true);
         $terminalWidthOption->setApplication($this->application);
         $commandProcessor = new CommandProcessor($hookManager);
         $commandProcessor->setFormatterManager($formatter);

--- a/tests/testHelp.php
+++ b/tests/testHelp.php
@@ -300,7 +300,9 @@ EOT;
         }
     },
     "help": "Test command with formatters",
-    "alias": "extab",
+    "aliases": [
+        "extab"
+    ],
     "topics": [
         "docs-tables"
     ]


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
WordWrap is now automatically disabled when stdout is not connected to a terminal.

### Description
Prior to this change, `myapp | grep regex` could be subject to random failures or strange truncated results if the output is longer than the terminal width, as word wrapping was being done regardless of whether or not stdout was directed at a terminal.

This PR disables wordwrap by default when stdout is redirected.