### PR TITLE
Do not change word-wrapping behavior

### DIFF
--- a/src/Options/PrepareTerminalWidthOption.php
+++ b/src/Options/PrepareTerminalWidthOption.php
@@ -27,12 +27,6 @@ class PrepareTerminalWidthOption implements PrepareFormatter
     public function __construct($defaultWidth = 0)
     {
         $this->defaultWidth = $defaultWidth;
-
-        // If STDOUT is not attached to a terminal, then disable
-        // automatic width detection.
-        if (function_exists('posix_isatty') && !posix_isatty(STDOUT)) {
-            $this->shouldWrap = false;
-        }
     }
 
     public function setApplication(Application $application)


### PR DESCRIPTION
… based on whether or not stdout has been redirected. Use '--format=tsv' to avoid wrapping in scripts.

### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes (deletes some untested code, so that's good, right? ;> )
