### PR TITLE
Allow phpdocumentor/reflection-docblock 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/console": "^2.8|~3",
         "symfony/event-dispatcher": "^2.5|^3",
         "symfony/finder": "^2.5|^3",
-        "phpdocumentor/reflection-docblock": "^2.0|^3.0.2"
+        "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Allow phpdocumentor/reflection-docblock 4

