### PR TITLE
Symfony IO parameters fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The Annotated-Command project is completely agnostic to logging. If a command wi
 
 If you want to use annotations, but still want access to the Symfony Command, e.g. to get a reference to the helpers in order to call some legacy code, you may create an ordinary Symfony Command that extends \Consolidation\AnnotatedCommand\AnnotatedCommand, which is a \Symfony\Component\Console\Command\Command. Omit the configure method, and place your annotations on the `execute()` method.
 
-It is also possible to add InputInterface or OutputInterface parameters to any annotated method of a command file.
+It is also possible to add InputInterface and/or OutputInterface parameters to any annotated method of a command file (the parameters must go before command arguments).
 
 ## API Usage
 

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -3,8 +3,6 @@ namespace Consolidation\AnnotatedCommand;
 
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
-use Consolidation\OutputFormatters\FormatterManager;
-use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\AnnotatedCommand\Help\HelpDocumentAlter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -225,8 +223,11 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
      */
     protected function checkUsesInputInterface($params)
     {
+        /** @var \ReflectionParameter $firstParam */
         $firstParam = reset($params);
-        return $firstParam instanceof InputInterface;
+        return $firstParam && $firstParam->getClass() && $firstParam->getClass()->implementsInterface(
+            '\\Symfony\\Component\\Console\\Input\\InputInterface'
+        );
     }
 
     /**
@@ -251,7 +252,11 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
         $index = $this->checkUsesInputInterface($params) ? 1 : 0;
         $this->usesOutputInterface =
             (count($params) > $index) &&
-            ($params[$index] instanceof OutputInterface);
+            $params[$index]->getClass() &&
+            $params[$index]->getClass()->implementsInterface(
+                '\\Symfony\\Component\\Console\\Output\\OutputInterface'
+            )
+        ;
         return $this;
     }
 
@@ -428,8 +433,8 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
         );
 
         $commandData->setUseIOInterfaces(
-            $this->usesOutputInterface,
-            $this->usesInputInterface
+            $this->usesInputInterface,
+            $this->usesOutputInterface
         );
 
         return $commandData;

--- a/src/CommandData.php
+++ b/src/CommandData.php
@@ -93,12 +93,12 @@ class CommandData
         // to the beginning.
         array_shift($args);
 
-        if ($this->usesInputInterface) {
-            array_unshift($args, $this->input());
-        }
-
         if ($this->usesOutputInterface) {
             array_unshift($args, $this->output());
+        }
+
+        if ($this->usesInputInterface) {
+            array_unshift($args, $this->input());
         }
 
         return $args;

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -100,6 +100,16 @@ class ExampleCommandFile
     }
 
     /**
+     * This command work with app's input and output
+     *
+     * @command command:with-io-parameters
+     */
+    public function commandWithIOParameters(InputInterface $input, OutputInterface $output)
+    {
+        return $input->getFirstArgument();
+    }
+
+    /**
      * This command has no arguments--only options
      *
      * Return a result only if not silent.

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -254,6 +254,24 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         );
     }
 
+    function testCommandWithIOParameters()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'commandWithIOParameters');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
+        $this->assertEquals('command:with-io-parameters', $command->getName());
+        $this->assertEquals("This command work with app's input and output", $command->getDescription());
+        $this->assertEquals('', $command->getHelp());
+        $this->assertEquals('command:with-io-parameters', $command->getSynopsis());
+
+        $input = new StringInput('command:with-io-parameters');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'command:with-io-parameters');
+    }
+
     function testCommandWithNoArguments()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Currently handling of `InputInterface` & `OutputInterface` arguments is broken, so this PR fixes it.

### Description
The feature doesn't work at all now, seems that nobody has used it before.