### PR TITLE
Follow symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.4.12 - 24 Aug 2017
+
+- BUGFIX: Allow annotated commands to directly use InputInterface and OutputInterface (#106)
+
 ### 2.4.11 - 27 July 2017
 
 - Back out #102: do not change behavior of word wrap based on STDOUT redirection.

--- a/src/CommandFileDiscovery.php
+++ b/src/CommandFileDiscovery.php
@@ -40,6 +40,8 @@ class CommandFileDiscovery
     protected $includeFilesAtBase = true;
     /** @var integer */
     protected $searchDepth = 2;
+    /** @var bool */
+    protected $followLinks = false;
 
     public function __construct()
     {
@@ -98,6 +100,16 @@ class CommandFileDiscovery
     public function setSearchDepth($searchDepth)
     {
         $this->searchDepth = $searchDepth;
+        return $this;
+    }
+
+    /**
+     * Specify that the discovery object should follow symlinks. By
+     * default, symlinks are not followed.
+     */
+    public function followLinks($followLinks = true)
+    {
+        $this->followLinks = $followLinks;
         return $this;
     }
 
@@ -323,6 +335,10 @@ class CommandFileDiscovery
 
         foreach ($this->excludeList as $item) {
             $finder->exclude($item);
+        }
+
+        if ($this->followLinks) {
+            $finder->followLinks();
         }
 
         return $finder;


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Adds a new method `followSymlinks()` that causes discovery class to follow symlinks.
