### PR TITLE
Replace default option value of 'null' with InputOption::VALUE_OPTIONAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.5.0 - 16 Sep 2017
+
+- BUGFIX: Improve handling of options with optional values, which previously was not working correctly. (#118)
+
 ### 2.4.13 - 28 Aug 2017
 
 - Add a followLinks() method (#108)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ The `$options` array must be an associative array whose key is the name of the o
 - A **string** containing the default value for options that may be provided a value, but are not required to.
 - NULL for options that may be provided an optional value, but that have no default when a value is not provided.
 - The special value InputOption::VALUE_REQUIRED, which indicates that the user must provide a value for the option whenever it is used.
+- The special value InputOption::VALUE_OPTIONAL, which produces the following behavior:
+  - If the option is given a value (e.g. `--foo=bar`), then the value will be a string.
+  - If the option exists on the commandline, but has no value (e.g. `--foo`), then the value will be `true`.
+  - If the option does not exist on the commandline at all, then the value will be `false`.
+  - LIMITATION: If any Input object other than ArgvInput (or a subclass thereof) is used, then the value will be `null` for both the no-value case (`--foo`) and the no-option case. When using a StringInput, use `--foo=1` instead of `--foo` to avoid this problem.
 - An empty array, which indicates that the option may appear multiple times on the command line.
 
 No other values should be used for the default value. For example, `$options = ['a' => 1]` is **incorrect**; instead, use `$options = ['a' => '1']`. Similarly, `$options = ['a' => true]` is unsupported, or at least not useful, as this would indicate that the value of `--a` was always `true`, whether or not it appeared on the command line.

--- a/src/CommandData.php
+++ b/src/CommandData.php
@@ -1,6 +1,7 @@
 <?php
 namespace Consolidation\AnnotatedCommand;
 
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -80,7 +81,23 @@ class CommandData
 
     public function options()
     {
-        return $this->input->getOptions();
+        $options = $this->input->getOptions();
+
+        // If Input isn't an ArgvInput, then return the options as-is.
+        if (!$this->input instanceof ArgvInput) {
+            return $options;
+        }
+
+        // If we have an ArgvInput, then we can determine if options
+        // are missing from the command line. Convert any missing
+        // options with a 'null' value to 'true' or false'.
+        foreach ($options as $option => $value) {
+            if ($value === null) {
+                $options[$option] = $this->input->hasParameterOption("--$option");
+            }
+        }
+
+        return $options;
     }
 
     public function getArgsWithoutAppName()

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -496,6 +496,16 @@ class CommandInfo
                 list($fullName, $shortcut) = explode('|', $name, 2);
             }
 
+            // Treat the following three cases identically:
+            //   - 'foo' => InputOption::VALUE_OPTIONAL
+            //   - 'foo' => true
+            //   - 'foo' => null
+            // The first form is preferred, but we will convert all
+            // forms to 'null' for storage as the option default value.
+            if (($defaultValue === InputOption::VALUE_OPTIONAL) || ($defaultValue === true)) {
+                $defaultValue = null;
+            }
+
             if (is_bool($defaultValue)) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_NONE, $description);
             } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -411,6 +411,14 @@ class ExampleCommandFile
     }
 
     /**
+     * @return string
+     */
+    public function defaultOptionalValue($options = ['foo' => InputOption::VALUE_OPTIONAL])
+    {
+        return "Foo is " . var_export($options['foo'], true);
+    }
+
+    /**
      * This is the test:required-array-option command
      *
      * This command will print all the valused of passed option

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -61,6 +61,27 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertRunCommandViaApplicationContains($command, $input, ['The "--foo" option requires a value.'], 1);
     }
 
+    function testOptionWithOptionalValue()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'defaultOptionalValue');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        // Test to see if we can differentiate between a missing option, and
+        // an option that has no value at all.
+        $input = new StringInput('default:optional-value --foo=bar');
+        $this->assertRunCommandViaApplicationEquals($command, $input, "Foo is 'bar'");
+
+        $input = new StringInput('default:optional-value --foo');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is true');
+
+        $input = new StringInput('default:optional-value');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is false');
+    }
+
     /**
      * Test CommandInfo command caching.
      *


### PR DESCRIPTION
This allows us to improve the handing of options which may or may not have been specified by the user on the commandline.

### Disposition
This pull request:

- [X] Fixes a bug
- [X] Adds a feature
- [X] Breaks backwards compatibility (only for apps using broken functionality)
- [X] Has tests that cover changes

### Summary
Instead of `'foo' => null` (which did not produce correct results), applications should now instead use `'foo' => InputOption::VALUE_OPTIONAL`.

### Description

Paraphrased from the README:

The special value InputOption::VALUE_OPTIONAL produces the following behavior:
  - If the option is given a value (e.g. `--foo=bar`), then the value will be a string.
  - If the option exists on the commandline, but has no value (e.g. `--foo`), then the value will be `true`.
  - If the option does not exist on the commandline at all, then the value will be `false`.

LIMITATION: If any Input object other than ArgvInput (or a subclass thereof) is used, then the value will be `null` unless explicitly provided. In this case, there is no way to distinguish between `--foo`, and a similar commandline where the option does not appear. When using a StringInput or ArrayInput, use `--foo=1` to work around this limitation.

BACKWARDS COMPATIBLITY BREAK:

Formerly, `'foo' => null` would return a value of 'null' when the option was omitted from the commandline. Now, it will behave as above (value will be 'false').

This backward compatibility break is considered acceptable for a non-major release of the library only because the existing behavior was broken (a `null` value would also be returned for `--foo` with no value), and therefore not likely to be in widespread use.