### PR TITLE
Support special option default value of 'true'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.5.1 - 17 Sep 2017
+
+- Add support for options with a default value of 'true' (#119)
+
 ### 2.5.0 - 16 Sep 2017
 
 - BUGFIX: Improve handling of options with optional values, which previously was not working correctly. (#118)

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ The `$options` array must be an associative array whose key is the name of the o
 
 - The boolean value `false`, which indicates that the option takes no value.
 - A **string** containing the default value for options that may be provided a value, but are not required to.
-- NULL for options that may be provided an optional value, but that have no default when a value is not provided.
 - The special value InputOption::VALUE_REQUIRED, which indicates that the user must provide a value for the option whenever it is used.
 - The special value InputOption::VALUE_OPTIONAL, which produces the following behavior:
   - If the option is given a value (e.g. `--foo=bar`), then the value will be a string.
   - If the option exists on the commandline, but has no value (e.g. `--foo`), then the value will be `true`.
   - If the option does not exist on the commandline at all, then the value will be `false`.
   - LIMITATION: If any Input object other than ArgvInput (or a subclass thereof) is used, then the value will be `null` for both the no-value case (`--foo`) and the no-option case. When using a StringInput, use `--foo=1` instead of `--foo` to avoid this problem.
+- The special value `true`. Note that if the default value of `--foo` is true, then the value of the `foo` option will be `true` when `--foo` is omitted from the commandline. Use `--foo=0` or `--no-foo` to set the value to `false`. The option may also be given other values (e.g. `--foo=bar`).
 - An empty array, which indicates that the option may appear multiple times on the command line.
 
 No other values should be used for the default value. For example, `$options = ['a' => 1]` is **incorrect**; instead, use `$options = ['a' => '1']`. Similarly, `$options = ['a' => true]` is unsupported, or at least not useful, as this would indicate that the value of `--a` was always `true`, whether or not it appeared on the command line.

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -437,6 +437,11 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
             $this->usesOutputInterface
         );
 
+        // Allow the commandData to cache the list of options with
+        // special default values ('null' and 'true'), as these will
+        // need special handling. @see CommandData::options().
+        $commandData->cacheSpecialDefaults($this->getDefinition());
+
         return $commandData;
     }
 }

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -502,11 +502,11 @@ class CommandInfo
             //   - 'foo' => null
             // The first form is preferred, but we will convert all
             // forms to 'null' for storage as the option default value.
-            if (($defaultValue === InputOption::VALUE_OPTIONAL) || ($defaultValue === true)) {
+            if ($defaultValue === InputOption::VALUE_OPTIONAL) {
                 $defaultValue = null;
             }
 
-            if (is_bool($defaultValue)) {
+            if ($defaultValue === false) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_NONE, $description);
             } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description);

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -482,9 +482,24 @@ class CommandInfo
         return $this->inputOptions;
     }
 
+    protected function addImplicitNoOptions()
+    {
+        $opts = $this->options()->getValues();
+        foreach ($opts as $name => $defaultValue) {
+            if ($defaultValue === true) {
+                $key = 'no-' . $name;
+                if (!array_key_exists($key, $opts)) {
+                    $description = "Negate --$name option.";
+                    $this->options()->add($key, $description, false);
+                }
+            }
+        }
+    }
+
     protected function createInputOptions()
     {
         $explicitOptions = [];
+        $this->addImplicitNoOptions();
 
         $opts = $this->options()->getValues();
         foreach ($opts as $name => $defaultValue) {

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -419,6 +419,14 @@ class ExampleCommandFile
     }
 
     /**
+     * @return string
+     */
+    public function defaultOptionDefaultsToTrue($options = ['foo' => true])
+    {
+        return "Foo is " . var_export($options['foo'], true);
+    }
+
+    /**
      * This is the test:required-array-option command
      *
      * This command will print all the valused of passed option

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -101,6 +101,18 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
 
         $input = new StringInput('default:option-defaults-to-true');
         $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is true');
+
+        $input = new StringInput('help default:option-defaults-to-true');
+        $this->assertRunCommandViaApplicationContains(
+            $command,
+            $input,
+            [
+                '--no-foo',
+                'Negate --foo option',
+            ]
+        );
+        $input = new StringInput('default:option-defaults-to-true --no-foo');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is false');
     }
     /**
      * Test CommandInfo command caching.

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -82,6 +82,26 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is false');
     }
 
+    function testOptionThatDefaultsToTrue()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'defaultOptionDefaultsToTrue');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        // Test to see if we can differentiate between a missing option, and
+        // an option that has no value at all.
+        $input = new StringInput('default:option-defaults-to-true --foo=bar');
+        $this->assertRunCommandViaApplicationEquals($command, $input, "Foo is 'bar'");
+
+        $input = new StringInput('default:option-defaults-to-true --foo');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is true');
+
+        $input = new StringInput('default:option-defaults-to-true');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is true');
+    }
     /**
      * Test CommandInfo command caching.
      *


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Options may now have a default value of `true`.

### Description
See updated description in README.
