### PR TITLE
Update CHANGELOG for 2.6.0 release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   # Only test the master branch and SemVer tags.
   only:
     - master
+    - 2.x
     - /^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*$/
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.6.0 - 18 Sep 2017
+
+- Revert to version 2.4.9, backing out breaking changes in 2.5.x.
+
 ### 2.4.9 - 20 Jul 2017
 
 - Automatically disable wordwrap when the terminal is not connected to STDOUT (#102)


### PR DESCRIPTION
### Disposition
This pull request:

- [X] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
Versions in the 2.5.x range were not sufficiently backwards-compatible with the 2.x line of Annotated Command, breaking some users.  This release rolls back those changes.
