### PR TITLE
Bring back the features from the 2.5.x branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Change Log
 
-### 2.5.1 - 17 Sep 2017
+### 2.7.0
 
 - Add support for options with a default value of 'true' (#119)
-
-### 2.5.0 - 16 Sep 2017
-
 - BUGFIX: Improve handling of options with optional values, which previously was not working correctly. (#118)
+
+### 2.6.1 - 18 Sep 2017
+
+- Reverts to contents of the 2.4.13 release.
+
+### 2.5.0 & 2.5.1 - 17 Sep 2017
+
+- BACKED OUT. These releases accidentally introduced breaking changes.
 
 ### 2.4.13 - 28 Aug 2017
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,15 @@ The `$options` array must be an associative array whose key is the name of the o
 - The special value InputOption::VALUE_OPTIONAL, which produces the following behavior:
   - If the option is given a value (e.g. `--foo=bar`), then the value will be a string.
   - If the option exists on the commandline, but has no value (e.g. `--foo`), then the value will be `true`.
-  - If the option does not exist on the commandline at all, then the value will be `false`.
+  - If the option does not exist on the commandline at all, then the value will be `null`.
+  - If the user explicitly sets `--foo=0`, then the value will be converted to `false`.
   - LIMITATION: If any Input object other than ArgvInput (or a subclass thereof) is used, then the value will be `null` for both the no-value case (`--foo`) and the no-option case. When using a StringInput, use `--foo=1` instead of `--foo` to avoid this problem.
-- The special value `true`. Note that if the default value of `--foo` is true, then the value of the `foo` option will be `true` when `--foo` is omitted from the commandline. Use `--foo=0` or `--no-foo` to set the value to `false`. The option may also be given other values (e.g. `--foo=bar`).
+- The special value `true` produces the following behavior:
+  - If the option is given a value (e.g. `--foo=bar`), then the value will be a string.
+  - If the option exists on the commandline, but has no value (e.g. `--foo`), then the value will be `true`.
+  - If the option does not exist on the commandline at all, then the value will also be `true`.
+  - If the user explicitly sets `--foo=0`, then the value will be converted to `false`.
+  - If the user adds `--no-foo` on the commandline, then the value of `foo` will be `false`.
 - An empty array, which indicates that the option may appear multiple times on the command line.
 
 No other values should be used for the default value. For example, `$options = ['a' => 1]` is **incorrect**; instead, use `$options = ['a' => '1']`. Similarly, `$options = ['a' => true]` is unsupported, or at least not useful, as this would indicate that the value of `--a` was always `true`, whether or not it appeared on the command line.

--- a/src/CommandData.php
+++ b/src/CommandData.php
@@ -115,17 +115,18 @@ class CommandData
         }
 
         // If we have an ArgvInput, then we can determine if options
-        // are missing from the command line. Convert any missing
-        // options with a 'null' value to 'true' or false'.
+        // are missing from the command line. If the option value is
+        // missing from $input, then we will keep the value `null`.
+        // If it is present, but has no explicit value, then change it its
+        // value to `true`.
         foreach ($options as $option => $value) {
-            if ($value === null) {
-                $options[$option] = $this->input->hasParameterOption("--$option");
+            if (($value === null) && ($this->input->hasParameterOption("--$option"))) {
+                $options[$option] = true;
             }
         }
 
         return $options;
     }
-
 
     protected function shouldConvertOptionToFalse($options, $option, $value)
     {

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -511,12 +511,11 @@ class CommandInfo
                 list($fullName, $shortcut) = explode('|', $name, 2);
             }
 
-            // Treat the following three cases identically:
+            // Treat the following two cases identically:
             //   - 'foo' => InputOption::VALUE_OPTIONAL
-            //   - 'foo' => true
             //   - 'foo' => null
-            // The first form is preferred, but we will convert all
-            // forms to 'null' for storage as the option default value.
+            // The first form is preferred, but we will convert the value
+            // to 'null' for storage as the option default value.
             if ($defaultValue === InputOption::VALUE_OPTIONAL) {
                 $defaultValue = null;
             }

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -79,7 +79,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is true');
 
         $input = new StringInput('default:optional-value');
-        $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is false');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'Foo is NULL');
     }
 
     function testOptionThatDefaultsToTrue()


### PR DESCRIPTION
This time, ensure that the 'missing' value for options with optional values that are not included on the commandline remains 'null'. This should preserve backwards compatibility.

### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [X] Has tests that cover changes

### Summary
See description in README
