### PR TITLE
Command method and name checks

### DIFF
--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -321,8 +321,9 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         if ($commandInfo->hasAnnotation('command')) {
             return true;
         }
-        // Skip anything that has an invalid name.
-        if (empty($commandInfo->getName())) {
+        // Skip anything that has a missing or invalid name.
+        $commandName = $commandInfo->getName();
+        if (empty($commandName) || preg_match('#[^a-zA-Z0-9:_-]#', $commandName)) {
             return false;
         }
         // Skip anything named like an accessor ('get' or 'set')

--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -246,8 +246,9 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         // can never be commands.
         $commandMethodNames = array_filter(
             get_class_methods($classNameOrInstance) ?: [],
-            function ($m) {
-                return !preg_match('#^_#', $m);
+            function ($m) use ($classNameOrInstance) {
+                $reflectionMethod = new \ReflectionMethod($classNameOrInstance, $m);
+                return !$reflectionMethod->isStatic() && !preg_match('#^_#', $m);
             }
         );
 
@@ -319,6 +320,10 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         // Include everything labeled @command
         if ($commandInfo->hasAnnotation('command')) {
             return true;
+        }
+        // Skip anything that has an invalid name.
+        if (empty($commandInfo->getName())) {
+            return false;
         }
         // Skip anything named like an accessor ('get' or 'set')
         if (preg_match('#^(get[A-Z]|set[A-Z])#', $commandInfo->getMethodName())) {

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -30,6 +30,11 @@ class AlphaCommandFile implements CustomEventAwareInterface
         return new CommandError('This command always fails.', 13);
     }
 
+    public static function ignoredStaticMethod()
+    {
+        return 'This method is static; it should not generate a command.';
+    }
+
     /**
      * @command simulated:status
      */


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Allegedly, public static methods in a commandfile produce an invalid CommandInfo structure with an empty command name, crashing Symfony Console.  This PR attempt to define a failing test, and then fix it. However, the test does not identify the problem (all tests pass, when in theory some should fail).

Fixes https://github.com/drush-ops/drush/issues/2919
