### PR TITLE
Allow $options parameter to be empty.

### DIFF
--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -631,7 +631,7 @@ class CommandInfo
         $result = new DefaultsWithDescriptions();
         $params = $this->reflection->getParameters();
         $optionsFromParameters = $this->determineOptionsFromParameters();
-        if (!empty($optionsFromParameters)) {
+        if ($this->lastParameterIsOptionsArray()) {
             array_pop($params);
         }
         foreach ($params as $param) {
@@ -683,6 +683,28 @@ class CommandInfo
             return [];
         }
         return $param->getDefaultValue();
+    }
+
+    /**
+     * Determine if the last argument contains $options.
+     *
+     * Two forms indicate options:
+     * - $options = []
+     * - $options = ['flag' => 'default-value']
+     *
+     * Any other form, including `array $foo`, is not options.
+     */
+    protected function lastParameterIsOptionsArray()
+    {
+        $params = $this->reflection->getParameters();
+        if (empty($params)) {
+            return [];
+        }
+        $param = end($params);
+        if (!$param->isDefaultValueAvailable()) {
+            return [];
+        }
+        return is_array($param->getDefaultValue());
     }
 
     /**

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -451,4 +451,12 @@ class ExampleCommandFile
     {
         return implode(' ', $opts['arr']);
     }
+
+    /**
+     * @command global-options-only
+     */
+    public function globalOptionsOnly($arg, $options = [])
+    {
+        return "Arg is $arg, options[help] is " . var_export($options['help'], true) . "\n";
+    }
 }

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -61,6 +61,18 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertRunCommandViaApplicationContains($command, $input, ['The "--foo" option requires a value.'], 1);
     }
 
+    function testGlobalOptionsOnly()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'globalOptionsOnly');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $input = new StringInput('global-options-only test');
+        $this->assertRunCommandViaApplicationEquals($command, $input, "Arg is test, options[help] is false");
+    }
+
     function testOptionWithOptionalValue()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
`$options = []` is now allowed as the last parameter of an annotated command function.

### Description
This behavior was inherited from the original annotation code in Robo, which assumed that there was no point in declaring the `$options` parameter for command scripts that have no options. However, some commands may not have any locally-defined options, but may still want access to the `$option` variable for the purpose of reading global options, options injected from an annotation hook, etc.

This PR allows this scenario to work.
