### PR TITLE
Add hook methods to allow Symfony command events to be added directly…

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,11 @@
+{
+    "timeout": 10,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection-log.txt"
+    }
+}

--- a/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
+++ b/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Call hooks
@@ -25,8 +26,11 @@ class CommandEventHookDispatcher extends HookDispatcher
         ];
         $commandEventHooks = $this->getHooks($hooks);
         foreach ($commandEventHooks as $commandEvent) {
+            if ($commandEvent instanceof EventDispatcherInterface) {
+                return $commandEvent->dispatch(ConsoleEvents::COMMAND, $event);
+            }
             if (is_callable($commandEvent)) {
-                $commandEvent($event);
+                return $commandEvent($event);
             }
         }
     }

--- a/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
+++ b/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
@@ -27,10 +27,10 @@ class CommandEventHookDispatcher extends HookDispatcher
         $commandEventHooks = $this->getHooks($hooks);
         foreach ($commandEventHooks as $commandEvent) {
             if ($commandEvent instanceof EventDispatcherInterface) {
-                return $commandEvent->dispatch(ConsoleEvents::COMMAND, $event);
+                $commandEvent->dispatch(ConsoleEvents::COMMAND, $event);
             }
             if (is_callable($commandEvent)) {
-                return $commandEvent($event);
+                $commandEvent($event);
             }
         }
     }

--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 use Consolidation\AnnotatedCommand\ExitCodeInterface;
 use Consolidation\AnnotatedCommand\OutputDataInterface;
@@ -130,6 +132,32 @@ class HookManager implements EventSubscriberInterface
     {
         $this->hooks[$name][self::REPLACE_COMMAND_HOOK][] = $replaceCommandHook;
         return $this;
+    }
+
+    public function addPreCommandEventDispatcher(EventDispatcherInterface $eventDispatcher, $name = '*')
+    {
+        $this->hooks[$name][self::PRE_COMMAND_EVENT][] = $eventDispatcher;
+        return $this;
+    }
+
+    public function addCommandEventDispatcher(EventDispatcherInterface $eventDispatcher, $name = '*')
+    {
+        $this->hooks[$name][self::COMMAND_EVENT][] = $eventDispatcher;
+        return $this;
+    }
+
+    public function addPostCommandEventDispatcher(EventDispatcherInterface $eventDispatcher, $name = '*')
+    {
+        $this->hooks[$name][self::POST_COMMAND_EVENT][] = $eventDispatcher;
+        return $this;
+    }
+
+    public function addCommandEvent(EventSubscriberInterface $eventSubscriber)
+    {
+        // Wrap the event subscriber in a dispatcher and add it
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($eventSubscriber);
+        return $this->addCommandEventDispatcher($dispatcher);
     }
 
     /**

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -972,7 +972,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
 
         $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
         $eventDispatcher->addSubscriber($this->commandFactory->commandProcessor()->hookManager());
-        $eventDispatcher->addSubscriber($alterOptionsEventManager);
+        $this->commandFactory->commandProcessor()->hookManager()->addCommandEvent($alterOptionsEventManager);
         $application->setDispatcher($eventDispatcher);
 
         $application->setAutoExit(false);

--- a/tests/testFullStack.php
+++ b/tests/testFullStack.php
@@ -39,7 +39,7 @@ class FullStackTests extends \PHPUnit_Framework_TestCase
         $alterOptionsEventManager = new AlterOptionsCommandEvent($this->application);
         $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
         $eventDispatcher->addSubscriber($this->commandFactory->commandProcessor()->hookManager());
-        $eventDispatcher->addSubscriber($alterOptionsEventManager);
+        $this->commandFactory->commandProcessor()->hookManager()->addCommandEvent($alterOptionsEventManager);
         $this->application->setDispatcher($eventDispatcher);
         $this->application->setAutoExit(false);
     }

--- a/tests/testHelp.php
+++ b/tests/testHelp.php
@@ -40,7 +40,7 @@ class HelpTests extends \PHPUnit_Framework_TestCase
         $alterOptionsEventManager = new AlterOptionsCommandEvent($this->application);
         $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
         $eventDispatcher->addSubscriber($this->commandFactory->commandProcessor()->hookManager());
-        $eventDispatcher->addSubscriber($alterOptionsEventManager);
+        $this->commandFactory->commandProcessor()->hookManager()->addCommandEvent($alterOptionsEventManager);
         $this->application->setDispatcher($eventDispatcher);
         $this->application->setAutoExit(false);
 


### PR DESCRIPTION
… to our hook manager.

### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Allow symfony event subscribers (and dispatchers) to be added to our hook manager, so that these events may be ordered correctly relative to the command events added via annotations.