### PR TITLE
Fixes #139: Do not shift off the command name unless it is there.

### DIFF
--- a/src/CommandData.php
+++ b/src/CommandData.php
@@ -170,7 +170,9 @@ class CommandData
         // will be the command name. The Application alters the
         // input definition to match, adding a 'command' argument
         // to the beginning.
-        array_shift($args);
+        if ($this->input->hasArgument('command')) {
+            array_shift($args);
+        }
 
         if ($this->usesOutputInterface) {
             array_unshift($args, $this->output());


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
The CommandData class is too indiscriminate about removing the command name.
