### PR TITLE
Improve commandfile discovery for extensions installed via Composer.

### DIFF
--- a/src/CommandFileDiscovery.php
+++ b/src/CommandFileDiscovery.php
@@ -27,6 +27,15 @@ use Symfony\Component\Finder\Finder;
  * To discover global commands:
  *
  * $commandFiles = $discovery->discover($drupalRoot, '\Drupal');
+ *
+ * WARNING:
+ *
+ * This class is deprecated. Commandfile discovery is complicated, and does
+ * not work from within phar files. It is recommended to instead use a static
+ * list of command classes as shown in https://github.com/g1a/starter/blob/master/example
+ *
+ * For a better alternative when implementing a plugin mechanism, see
+ * https://robo.li/extending/#register-command-files-via-psr-4-autoloading
  */
 class CommandFileDiscovery
 {
@@ -42,6 +51,8 @@ class CommandFileDiscovery
     protected $searchDepth = 2;
     /** @var bool */
     protected $followLinks = false;
+    /** @var string[] */
+    protected $strippedNamespaces;
 
     public function __construct()
     {
@@ -126,6 +137,28 @@ class CommandFileDiscovery
     }
 
     /**
+     * Set a particular namespace part to ignore. This is useful in plugin
+     * mechanisms where the plugin is placed by Composer.
+     *
+     * For example, Drush extensions are placed in `./drush/Commands`.
+     * If the Composer installer path is `"drush/Commands/contrib/{$name}": ["type:drupal-drush"]`,
+     * then Composer will place the command files in `drush/Commands/contrib`.
+     * The namespace should not be any different in this instance than if
+     * the extension were placed in `drush/Commands`, though, so Drush therefore
+     * calls `ignoreNamespacePart('Commands', 'contrib')`. This causes the
+     * `contrib` component to be removed from the namespace if it follows
+     * the namespace `Commands`.
+     */
+    public function ignoreNamespacePart($base, $ignore)
+    {
+        $replacementPart = '\\' . $base . '\\';
+        $ignoredPart = $replacementPart . $ignore . '\\';
+        $this->strippedNamespaces[$ignoredPart] = $replacementPart;
+
+        return $this;
+    }
+
+    /**
      * Add one more location to the search location list.
      *
      * @param string $location One more relative path to search
@@ -205,7 +238,32 @@ class CommandFileDiscovery
                 $this->discoverCommandFiles("$directory/src", $itemsNamespace)
             );
         }
-        return $commandFiles;
+        return $this->fixNamespaces($commandFiles);
+    }
+
+    /**
+     * fixNamespaces will alter the namespaces in the commandFiles
+     * result to remove the Composer placement directory, if any.
+     */
+    protected function fixNamespaces($commandFiles)
+    {
+        // Do nothing unless the client told us to remove some namespace components.
+        if (empty($this->strippedNamespaces)) {
+            return $commandFiles;
+        }
+
+        // Strip out any part of the namespace the client did not want.
+        // @see CommandFileDiscovery::ignoreNamespacePart
+        return array_map(
+            function ($fqcn) {
+                return str_replace(
+                    array_keys($this->strippedNamespaces),
+                    array_values($this->strippedNamespaces),
+                    $fqcn
+                );
+            },
+            $commandFiles
+        );
     }
 
     /**
@@ -304,8 +362,8 @@ class CommandFileDiscovery
         foreach ($finder as $file) {
             $relativePathName = $file->getRelativePathname();
             $relativeNamespaceAndClassname = str_replace(
-                ['/', '.php'],
-                ['\\', ''],
+                ['/', '-', '.php'],
+                ['\\', '_', ''],
                 $relativePathName
             );
             $classname = $this->joinNamespace([$baseNamespace, $relativeNamespaceAndClassname]);


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Adds support for project names with '-' and path components such as "custom" and "contrib"

### Description
When managing plugins / extensions with Composer, and placing them via Composer Installers, there will be additional directories placed by Composer that we need to account for when finding commandfiles.

For example, Drush has the following recommended installer path:
```
    "drush/Commands/contrib/{$name}": ["type:drupal-drush"]
```
If the Composer project has a name similar to `my-cool-plugin`, then the old discovery code would
produce a namespace that included dashes, and that included the `contrib` portion of the path. Both
of these things are undesirable. PHP namespaces cannot contain dashes, and if the namespace in
the plugin contains "contrib", then it would not be possible to commit a copy of the repository
in a "custom" directory, or directly in "drush/Commands".

This PR transliterates '-' to '_' in namespaces, and also allows clients to define namespace
path components (e.g. 'custom' and 'contrib') that should be removed before returning the discovered
paths and namespaces to the client.
