### PR TITLE
Add a new data type, CommandResult

### DIFF
--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -200,8 +200,7 @@ class CommandProcessor implements LoggerAwareInterface
         // result.
         if ($result instanceof ExitCodeInterface) {
             $status = $result->getExitCode();
-        }
-        else {
+        } else {
             $status = $statusCodeDispatcher->determineStatusCode($result);
             if (isset($status) && ($status != 0)) {
                 return $status;

--- a/src/CommandResult.php
+++ b/src/CommandResult.php
@@ -1,0 +1,71 @@
+<?php
+namespace Consolidation\AnnotatedCommand;
+
+/**
+ * Return a CommandResult as the result of a command to pass both an exit
+ * code and result data from a command.
+ *
+ * Usage:
+ *
+ *      return CommandResult::dataWithExitCode(new RowsOfFields($rows), 1);
+ *
+ * The CommandResult can also be used to unambiguously return just
+ * an exit code or just output data.
+ *
+ * Exit code only:
+ *
+ *      return CommandResult::dataWithExitCode(1);
+ *
+ * Data only:
+ *
+ *      return CommandResult::data(new RowsOfFields($rows));
+ *
+ * Historically, it has always been possible to return an integer to indicate
+ * that the result is an exit code, and other return types (typically array
+ * / ArrayObjects) indicating actual data with an implicit exit code of 0.
+ * Using a CommandResult is preferred, though, as it allows the result of the
+ * function to be unambiguously specified without type-based interpretation.
+ *
+ * @package Consolidation\AnnotatedCommand
+ */
+class CommandResult implements ExitCodeInterface, OutputDataInterface
+{
+    protected $data;
+    protected $exitCode;
+
+    protected function __construct($data = null, $exitCode = 0)
+    {
+        $this->data = $data;
+        $this->exitCode = $exitCode;
+    }
+
+    public static function exitCode($exitCode)
+    {
+        return new self($null, $exitCode);
+    }
+
+    public static function data($data)
+    {
+        return new self($data);
+    }
+
+    public static function dataWithExitCode($data, $exitCode)
+    {
+        return new self($data, $exitCode);
+    }
+
+    public function getExitCode()
+    {
+        return $this->exitCode;
+    }
+
+    public function getOutputData()
+    {
+        return $this->data;
+    }
+
+    public function setOutputData($data)
+    {
+        $this->data = $data;
+    }
+}

--- a/tests/FullStackTest.php
+++ b/tests/FullStackTest.php
@@ -318,7 +318,7 @@ EOT;
 
         $this->assertRunCommandViaApplicationEquals('get:serious', 'very serious');
         $this->assertRunCommandViaApplicationContains('get:lost', 'Command "get:lost" is not defined.', [], 1);
-        $this->assertRunCommandViaApplicationContains('get:both', 'Here is some data.', [], 1);
+        $this->assertRunCommandViaApplicationContains('get:both', 'Here is some data.', [], 3);
     }
 
     function testCommandsAndHooksWithBetaFolder()

--- a/tests/FullStackTest.php
+++ b/tests/FullStackTest.php
@@ -318,6 +318,7 @@ EOT;
 
         $this->assertRunCommandViaApplicationEquals('get:serious', 'very serious');
         $this->assertRunCommandViaApplicationContains('get:lost', 'Command "get:lost" is not defined.', [], 1);
+        $this->assertRunCommandViaApplicationContains('get:both', 'Here is some data.', [], 1);
     }
 
     function testCommandsAndHooksWithBetaFolder()

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -306,7 +306,7 @@ class AlphaCommandFile implements CustomEventAwareInterface
             'reason' => 'There was data and there was an exit code to report.',
             'message' => 'Here is some data.',
         ];
-        return CommandResult::data(new AssociativeList($outputData), 3);
+        return CommandResult::dataWithExitCode(new AssociativeList($outputData), 3);
     }
 
     /**

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -292,6 +292,24 @@ class AlphaCommandFile implements CustomEventAwareInterface
     }
 
     /**
+     * Test command with formatters using an associative list
+     *
+     * @command get:both
+     * @field-labels
+     *   reason: Reason
+     *   message: Message
+     * @return \Consolidation\OutputFormatters\StructuredData\AssociativeList
+     */
+    public function getBoth()
+    {
+        $outputData = [
+            'reason' => 'There was data and there was an exit code to report.',
+            'message' => 'Here is some data.',
+        ];
+        return CommandResult::data(new AssociativeList($outputData), 3);
+    }
+
+    /**
      * This command uses a custom event 'my-event' to collect data.  Note that
      * the event handlers will not be found unless the hook manager is
      * injected into this command handler object via `setHookManager()`

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -2,6 +2,7 @@
 namespace Consolidation\TestUtils\alpha;
 
 use Consolidation\AnnotatedCommand\CommandError;
+use Consolidation\AnnotatedCommand\CommandResult;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\AssociativeList;
 use Consolidation\AnnotatedCommand\AnnotationData;
@@ -107,7 +108,7 @@ class AlphaCommandFile implements CustomEventAwareInterface
             [ 'first' => 'Ichi', 'second' => 'Ni',   'third' => 'San'   ],
             [ 'first' => 'Uno',  'second' => 'Dos',  'third' => 'Tres'  ],
         ];
-        return new RowsOfFields($outputData);
+        return CommandResult::data(new RowsOfFields($outputData));
     }
 
     /**
@@ -137,7 +138,7 @@ class AlphaCommandFile implements CustomEventAwareInterface
             [ 'first' => 'Ichi', 'second' => 'Ni',   'third' => 'San'   ],
             [ 'first' => 'Uno',  'second' => 'Dos',  'third' => 'Tres'  ],
         ];
-        return new RowsOfFields($outputData);
+        return CommandResult::data(new RowsOfFields($outputData));
     }
 
     /**
@@ -158,7 +159,7 @@ class AlphaCommandFile implements CustomEventAwareInterface
                 'second' => 'This is the second column of the same table. It is also very long, and should be wrapped across multiple lines, just like the first column.',
             ]
         ];
-        return new RowsOfFields($data);
+        return CommandResult::data(new RowsOfFields($data));
     }
 
     /**
@@ -183,9 +184,11 @@ class AlphaCommandFile implements CustomEventAwareInterface
      */
     public function alterFormatters($result, CommandData $commandData)
     {
+        $data = $result->getOutputData();
         if ($commandData->input()->getOption('french')) {
-            $result[] = [ 'first' => 'Un',  'second' => 'Deux',  'third' => 'Trois'  ];
+            $data[] = [ 'first' => 'Un',  'second' => 'Deux',  'third' => 'Trois'  ];
         }
+        $result->setOutputData($data);
 
         return $result;
     }
@@ -240,7 +243,7 @@ class AlphaCommandFile implements CustomEventAwareInterface
             'mysql_port' => 16191,
             'mysql_database' => 'pantheon',
         ];
-        return new AssociativeList($outputData);
+        return CommandResult::data(new AssociativeList($outputData));
     }
 
     /**

--- a/tests/src/beta/BetaCommandFile.php
+++ b/tests/src/beta/BetaCommandFile.php
@@ -27,9 +27,11 @@ class BetaCommandFile
      */
     public function alterFormattersChinese($result, CommandData $commandData)
     {
+        $data = $result->getOutputData();
         if ($commandData->input()->getOption('chinese')) {
-            $result[] = [ 'first' => '壹',  'second' => '貳',  'third' => '叁'  ];
+            $data[] = [ 'first' => '壹',  'second' => '貳',  'third' => '叁'  ];
         }
+        $result->setOutputData($data);
 
         return $result;
     }
@@ -43,9 +45,11 @@ class BetaCommandFile
      */
     public function alterFormattersKanji($result, CommandData $commandData)
     {
+        $data = $result->getOutputData();
         if ($commandData->input()->getOption('kanji')) {
-            $result[] = [ 'first' => '一',  'second' => '二',  'third' => '三'  ];
+            $data[] = [ 'first' => '一',  'second' => '二',  'third' => '三'  ];
         }
+        $result->setOutputData($data);
 
         return $result;
     }


### PR DESCRIPTION
CommandResult allows a command to return a result that contains both an exit code and data (e.g. RowsOfFields et. al.)

### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
The existing API allows applications to define custom data types that may represent both an exit code and result data. This PR provides a standard class with this capability.