### PR TITLE
Make injection of InputInterface / OutputInterface general-purpose

### DIFF
--- a/src/CommandData.php
+++ b/src/CommandData.php
@@ -14,41 +14,40 @@ class CommandData
     /** var OutputInterface */
     protected $output;
     /** var boolean */
-    protected $usesInputInterface;
-    /** var boolean */
-    protected $usesOutputInterface;
-    /** var boolean */
     protected $includeOptionsInArgs;
     /** var array */
     protected $specialDefaults = [];
+    /** @var string[] */
+    protected $injectedInstances = [];
 
     public function __construct(
         AnnotationData $annotationData,
         InputInterface $input,
-        OutputInterface $output,
-        $usesInputInterface = false,
-        $usesOutputInterface = false
+        OutputInterface $output
     ) {
         $this->annotationData = $annotationData;
         $this->input = $input;
         $this->output = $output;
-        $this->usesInputInterface = false;
-        $this->usesOutputInterface = false;
         $this->includeOptionsInArgs = true;
     }
 
     /**
-     * For internal use only; indicates that the function to be called
-     * should be passed an InputInterface &/or an OutputInterface.
-     * @param booean $usesInputInterface
-     * @param boolean $usesOutputInterface
-     * @return self
+     * For internal use only; inject an instance to be passed back
+     * to the command callback as a parameter.
      */
-    public function setUseIOInterfaces($usesInputInterface, $usesOutputInterface)
+    public function injectInstance($injectedInstance)
     {
-        $this->usesInputInterface = $usesInputInterface;
-        $this->usesOutputInterface = $usesOutputInterface;
+        array_unshift($this->injectedInstances, $injectedInstance);
         return $this;
+    }
+
+    /**
+     * Provide a reference to the instances that will be added to the
+     * beginning of the parameter list when the command callback is invoked.
+     */
+    public function injectedInstances()
+    {
+        return $this->injectedInstances;
     }
 
     /**
@@ -172,14 +171,6 @@ class CommandData
         // to the beginning.
         if ($this->input->hasArgument('command')) {
             array_shift($args);
-        }
-
-        if ($this->usesOutputInterface) {
-            array_unshift($args, $this->output());
-        }
-
-        if ($this->usesInputInterface) {
-            array_unshift($args, $this->input());
         }
 
         return $args;

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -242,12 +242,35 @@ class CommandProcessor implements LoggerAwareInterface
     {
         $result = false;
         try {
-            $args = $commandData->getArgsAndOptions();
+            $args = array_merge(
+                $commandData->injectedInstances(),
+                $commandData->getArgsAndOptions()
+            );
             $result = call_user_func_array($commandCallback, $args);
         } catch (\Exception $e) {
             $result = $this->commandErrorForException($e);
         }
         return $result;
+    }
+
+    public function injectIntoCommandData($commandData, $injectedClasses)
+    {
+        foreach($injectedClasses as $injectedClass) {
+            $injectedInstance = $this->getInstanceToInject($commandData, $injectedClass);
+            $commandData->injectInstance($injectedInstance);
+        }
+    }
+
+    protected function getInstanceToInject(CommandData $commandData, $injectedClass)
+    {
+        switch ($injectedClass) {
+            case 'Symfony\Component\Console\Input\InputInterface':
+                return $commandData->input();
+            case 'Symfony\Component\Console\Output\OutputInterface':
+                return $commandData->output();
+        }
+
+        return null;
     }
 
     /**

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -89,6 +89,11 @@ class CommandInfo
     protected $returnType;
 
     /**
+     * @var string[]
+     */
+    protected $injectedClasses = [];
+
+    /**
      * Create a new CommandInfo class for a particular method of a class.
      *
      * @param string|mixed $classNameOrInstance The name of a class, or an
@@ -201,6 +206,12 @@ class CommandInfo
     {
         $this->parseDocBlock();
         return $this->returnType;
+    }
+
+    public function getInjectedClasses()
+    {
+        $this->parseDocBlock();
+        return $this->injectedClasses;
     }
 
     public function setReturnType($returnType)
@@ -633,6 +644,11 @@ class CommandInfo
         $optionsFromParameters = $this->determineOptionsFromParameters();
         if ($this->lastParameterIsOptionsArray()) {
             array_pop($params);
+        }
+        while(!empty($params) && ($params[0]->getClass() != null)) {
+            $param = array_shift($params);
+            $injectedClass = $param->getClass()->getName();
+            array_unshift($this->injectedClasses, $injectedClass);
         }
         foreach ($params as $param) {
             $this->addParameterToResult($result, $param);


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Annotated commands may declare as their first parameter an InputInterface or an OutputInterface, and the corresponding references will be injected to their parameter list when their callback is executed. This PR makes this facility general-purpose, so that applications that use annotated commands may allow additional class instances to be passed to the callback methods at runtime.
