### PR TITLE
Cache injected classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.11.0
+
+- Make injection of InputInterface / OutputInterface general-purpose (#179)
+
 ### 2.10.2 - 20 Dec 2018
 
 - Fix commands that have a @param annotation for their InputInterface/OutputInterface params (#176)

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.4.5",
         "consolidation/output-formatters": "^3.4",
         "psr/log": "^1",
         "symfony/console": "^2.8|^3|^4",

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -20,7 +20,7 @@ class CommandInfo
     /**
      * Serialization schema version. Incremented every time the serialization schema changes.
      */
-    const SERIALIZATION_SCHEMA_VERSION = 3;
+    const SERIALIZATION_SCHEMA_VERSION = 4;
 
     /**
      * @var \ReflectionMethod
@@ -212,6 +212,12 @@ class CommandInfo
     {
         $this->parseDocBlock();
         return $this->injectedClasses;
+    }
+
+    public function setInjectedClasses($injectedClasses)
+    {
+        $this->injectedClasses = $injectedClasses;
+        return $this;
     }
 
     public function setReturnType($returnType)

--- a/src/Parser/CommandInfoDeserializer.php
+++ b/src/Parser/CommandInfoDeserializer.php
@@ -45,6 +45,7 @@ class CommandInfoDeserializer
             ->setDescription($info_array['description'])
             ->replaceExampleUsages($info_array['example_usages'])
             ->setReturnType($info_array['return_type'])
+            ->setInjectedClasses($info_array['injected_classes'])
             ;
 
         $this->constructDefaultsWithDescriptions($commandInfo->arguments(), (array)$info_array['arguments']);

--- a/src/Parser/CommandInfoSerializer.php
+++ b/src/Parser/CommandInfoSerializer.php
@@ -23,6 +23,7 @@ class CommandInfoSerializer
             'class' => $className,
             'method_name' => $commandInfo->getMethodName(),
             'mtime' => filemtime($path),
+            'injected_classes' => [],
         ];
 
         // If this is a valid method / hook, then add more information.
@@ -38,6 +39,7 @@ class CommandInfoSerializer
             ];
             $info['arguments'] = $this->serializeDefaultsWithDescriptions($commandInfo->arguments());
             $info['options'] = $this->serializeDefaultsWithDescriptions($commandInfo->options());
+            $info['injected_classes'] = $commandInfo->getInjectedClasses();
         }
 
         return $info;


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes (code touched, but feature not explicitly tested)

### Summary
When the injected classes field was added to the command info class, the serializer / deserializers were not updated at the same time. This PR fixes that oversight.