### PR TITLE
Better handling of cache schema changes

### DIFF
--- a/src/Parser/CommandInfoDeserializer.php
+++ b/src/Parser/CommandInfoDeserializer.php
@@ -29,7 +29,7 @@ class CommandInfoDeserializer
             isset($cache['method_name']) &&
             isset($cache['mtime']) &&
             ($cache['schema'] > 0) &&
-            ($cache['schema'] <= CommandInfo::SERIALIZATION_SCHEMA_VERSION) &&
+            ($cache['schema'] == CommandInfo::SERIALIZATION_SCHEMA_VERSION) &&
             self::cachedMethodExists($cache);
     }
 
@@ -82,6 +82,7 @@ class CommandInfoDeserializer
             'parameters' => [],
             'arguments' => [],
             'options' => [],
+            'injected_classes' => [],
             'mtime' => 0,
         ];
     }


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Version 2.11.1 introduced problems when old cached CommandInfo processed by new version. Be more defensive for this and future updates.
