### PR TITLE
Default shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.11.2 - 1 Feb 2019
+
+- Fix handling of old caches from 2.11.1 that introduced upgrade errors.
+
 ### 2.11.1 - 31 Jan 2019
 
 - Cache injected classes (#182)

--- a/src/Parser/Internal/BespokeDocBlockParser.php
+++ b/src/Parser/Internal/BespokeDocBlockParser.php
@@ -137,7 +137,20 @@ class BespokeDocBlockParser
     {
         $variableName = $this->commandInfo->findMatchingOption($name);
         $description = static::removeLineBreaks($description);
+        list($description, $defaultValue) = $this->splitOutDefault($description);
         $set->add($variableName, $description);
+        if ($defaultValue !== null) {
+            $set->setDefaultValue($variableName, $defaultValue);
+        }
+    }
+
+    protected function splitOutDefault($description)
+    {
+        if (!preg_match('#(.*)(Default: *)(.*)#', trim($description), $matches)) {
+            return [$description, null];
+        }
+
+        return [trim($matches[1]), $this->interpretDefaultValue(trim($matches[3]))];
     }
 
     /**

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -76,10 +76,8 @@ class ExampleCommandFile
      * the usual "parameter arguments".
      *
      * @param InputInterface $input
-     * @arg array $a A list of commandline parameters.
-     * @option foo
-     * @default a []
-     * @default foo []
+     * @arg array $a A list of commandline parameters. Default: []
+     * @option foo Default: []
      */
     public function testSymfony(InputInterface $input, OutputInterface $output)
     {


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Allow option default values to be defined inside the description for the option's annotation, as in:
```
@option $foo A foo field. Default: bar
```