### PR TITLE
Let's try to run our tests on 'trusty' and see if that allows old php…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 branches:
   # Only test the master branch and SemVer tags.


### PR DESCRIPTION
… versions to work

### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes (fixes a bug in tests -- we hope)

### Summary
Old php versions fail on Travis. In theory, pinning our distro to 'trusty' will allow them to work again.