### PR TITLE
Remove unused namespace declaring

### DIFF
--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -1,19 +1,13 @@
 <?php
 namespace Consolidation\AnnotatedCommand;
 
-use Consolidation\AnnotatedCommand\AnnotationData;
-use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
-use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Consolidation\TestUtils\ExampleCommandInfoAlterer;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\AnnotatedCommand\Input\StdinHandler;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/AnnotatedCommandTest.php
+++ b/tests/AnnotatedCommandTest.php
@@ -1,9 +1,6 @@
 <?php
 namespace Consolidation\AnnotatedCommand;
 
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Application;

--- a/tests/FullStackTest.php
+++ b/tests/FullStackTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Consolidation\AnnotatedCommand;
 
-use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandProcessor;
 use Consolidation\AnnotatedCommand\Hooks\AlterResultInterface;
@@ -14,16 +13,11 @@ use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Consolidation\OutputFormatters\FormatterManager;
 use Consolidation\TestUtils\TestTerminal;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\TestUtils\ApplicationWithTerminalWidth;
 use Consolidation\AnnotatedCommand\Options\PrepareTerminalWidthOption;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
-use Consolidation\AnnotatedCommand\Events\CustomEventAwareTrait;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/FullyQualifiedClassCacheTest.php
+++ b/tests/FullyQualifiedClassCacheTest.php
@@ -1,21 +1,7 @@
 <?php
 namespace Consolidation\AnnotatedCommand;
 
-use Consolidation\AnnotatedCommand\AnnotationData;
-use Consolidation\AnnotatedCommand\CommandData;
-use Consolidation\AnnotatedCommand\Hooks\HookManager;
-use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
-use Consolidation\AnnotatedCommand\Parser\CommandInfo;
-use Consolidation\TestUtils\ExampleCommandInfoAlterer;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\OutputInterface;
-
-use \Consolidation\AnnotatedCommand\Parser\Internal\FullyQualifiedClassCache;
+use Consolidation\AnnotatedCommand\Parser\Internal\FullyQualifiedClassCache;
 use PHPUnit\Framework\TestCase;
 
 class FullyQualifiedClassCacheTest extends TestCase

--- a/tests/HelpTest.php
+++ b/tests/HelpTest.php
@@ -3,24 +3,10 @@ namespace Consolidation\AnnotatedCommand;
 
 use Consolidation\AnnotatedCommand\Help\HelpCommand;
 
-use Consolidation\AnnotatedCommand\AnnotationData;
-use Consolidation\AnnotatedCommand\CommandData;
-use Consolidation\AnnotatedCommand\CommandProcessor;
-use Consolidation\AnnotatedCommand\Hooks\AlterResultInterface;
-use Consolidation\AnnotatedCommand\Hooks\ExtractOutputInterface;
-use Consolidation\AnnotatedCommand\Hooks\HookManager;
-use Consolidation\AnnotatedCommand\Hooks\ProcessResultInterface;
-use Consolidation\AnnotatedCommand\Hooks\StatusDeterminerInterface;
-use Consolidation\AnnotatedCommand\Hooks\ValidatorInterface;
 use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
-use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Consolidation\OutputFormatters\FormatterManager;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\TestUtils\ApplicationWithTerminalWidth;
 use Consolidation\AnnotatedCommand\Options\PrepareTerminalWidthOption;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [X] Enhancement

### Summary
- Removing unused namespace declaring  because they're unused.

### Description
- It seems that these namespaces 