### PR TITLE
Inject $input and $output into the command instance if it is set up to receive them.

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -364,5 +364,4 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
     {
         InjectionHelper::injectIntoCallbackObject($this->commandCallback, $input, $output);
     }
-
 }

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -1,15 +1,17 @@
 <?php
 namespace Consolidation\AnnotatedCommand;
 
-use Consolidation\AnnotatedCommand\Hooks\HookManager;
-use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Consolidation\AnnotatedCommand\Help\HelpDocumentAlter;
+use Consolidation\AnnotatedCommand\Help\HelpDocumentBuilder;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\Output\OutputAwareInterface;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Consolidation\AnnotatedCommand\Help\HelpDocumentBuilder;
 
 /**
  * AnnotatedCommands are created automatically by the
@@ -274,6 +276,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
+        $this->injectIntoCommandfileInstance($input, $output);
         $this->commandProcessor()->interact(
             $input,
             $output,
@@ -284,6 +287,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
 
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
+        $this->injectIntoCommandfileInstance($input, $output);
         // Allow the hook manager a chance to provide configuration values,
         // if there are any registered hooks to do that.
         $this->commandProcessor()->initializeHook($input, $this->getNames(), $this->annotationData);
@@ -294,6 +298,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->injectIntoCommandfileInstance($input, $output);
         // Validate, run, process, alter, handle results.
         return $this->commandProcessor()->process(
             $output,
@@ -311,6 +316,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
      */
     public function processResults(InputInterface $input, OutputInterface $output, $results)
     {
+        $this->injectIntoCommandfileInstance($input, $output);
         $commandData = $this->createCommandData($input, $output);
         $commandProcessor = $this->commandProcessor();
         $names = $this->getNames();
@@ -346,5 +352,45 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
         $commandData->cacheSpecialDefaults($this->getDefinition());
 
         return $commandData;
+    }
+
+    /**
+     * Inject $input and $output into the command instance if it is set up to receive them.
+     *
+     * @param callable $commandCallback
+     * @param CommandData $commandData
+     */
+    protected function injectIntoCommandfileInstance(InputInterface $input, OutputInterface $output)
+    {
+        $commandfileInstance = $this->recoverCommandfileInstance();
+        if (!$commandfileInstance) {
+            return;
+        }
+
+        if ($commandfileInstance instanceof InputAwareInterface) {
+            $commandfileInstance->setInput($input);
+        }
+        if ($commandfileInstance instanceof OutputAwareInterface) {
+            $commandfileInstance->setOutput($output);
+        }
+    }
+
+    /**
+     * If the command callback is a method of an object, return the object.
+     *
+     * @param callable $commandCallback
+     * @return object|bool
+     */
+    protected function recoverCommandfileInstance()
+    {
+        if (!is_array($this->commandCallback)) {
+            return false;
+        }
+
+        if (!is_object($this->commandCallback[0])) {
+            return false;
+        }
+
+        return $this->commandCallback[0];
     }
 }

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -360,37 +360,9 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
      * @param callable $commandCallback
      * @param CommandData $commandData
      */
-    protected function injectIntoCommandfileInstance(InputInterface $input, OutputInterface $output)
+    public function injectIntoCommandfileInstance(InputInterface $input, OutputInterface $output)
     {
-        $commandfileInstance = $this->recoverCommandfileInstance();
-        if (!$commandfileInstance) {
-            return;
-        }
-
-        if ($commandfileInstance instanceof InputAwareInterface) {
-            $commandfileInstance->setInput($input);
-        }
-        if ($commandfileInstance instanceof OutputAwareInterface) {
-            $commandfileInstance->setOutput($output);
-        }
+        InjectionHelper::injectIntoCallbackObject($this->commandCallback, $input, $output);
     }
 
-    /**
-     * If the command callback is a method of an object, return the object.
-     *
-     * @param callable $commandCallback
-     * @return object|bool
-     */
-    protected function recoverCommandfileInstance()
-    {
-        if (!is_array($this->commandCallback)) {
-            return false;
-        }
-
-        if (!is_object($this->commandCallback[0])) {
-            return false;
-        }
-
-        return $this->commandCallback[0];
-    }
 }

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -253,7 +253,6 @@ class CommandProcessor implements LoggerAwareInterface
     {
         $result = false;
         try {
-            $this->injectIntoCommandInstance($commandCallback, $commandData);
             $args = $this->parameterInjection()->args($commandData);
             $result = call_user_func_array($commandCallback, $args);
         } catch (\Exception $e) {
@@ -262,54 +261,8 @@ class CommandProcessor implements LoggerAwareInterface
         return $result;
     }
 
-    /**
-     * Use the parameter injection manager to provide injected classes to command data.
-     *
-     * @param CommandData $commandData
-     * @param array $injectedClasses
-     */
     public function injectIntoCommandData($commandData, $injectedClasses)
     {
         $this->parameterInjection()->injectIntoCommandData($commandData, $injectedClasses);
-    }
-
-    /**
-     * Inject $input and $output into the command instance if it is set up to receive them.
-     *
-     * @param callable $commandCallback
-     * @param CommandData $commandData
-     */
-    protected function injectIntoCommandInstance($commandCallback, CommandData $commandData)
-    {
-        $commandInstance = $this->recoverObject($commandCallback);
-        if (!$commandInstance) {
-            return;
-        }
-
-        if ($commandInstance instanceof InputAwareInterface) {
-            $commandInstance->setInput($commandData->input());
-        }
-        if ($commandInstance instanceof OutputAwareInterface) {
-            $commandInstance->setInput($commandData->output());
-        }
-    }
-
-    /**
-     * If the command callback is a method of an object, return the object.
-     *
-     * @param callable $commandCallback
-     * @return object|bool
-     */
-    protected function recoverObject($commandCallback)
-    {
-        if (!is_array($commandCallback)) {
-            return false;
-        }
-
-        if (!is_object($commandCallback[0])) {
-            return false;
-        }
-
-        return $commandCallback[0];
     }
 }

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -253,6 +253,7 @@ class CommandProcessor implements LoggerAwareInterface
     {
         $result = false;
         try {
+            $this->injectIntoCommandInstance($commandCallback, $commandData);
             $args = $this->parameterInjection()->args($commandData);
             $result = call_user_func_array($commandCallback, $args);
         } catch (\Exception $e) {
@@ -261,8 +262,54 @@ class CommandProcessor implements LoggerAwareInterface
         return $result;
     }
 
+    /**
+     * Use the parameter injection manager to provide injected classes to command data.
+     *
+     * @param CommandData $commandData
+     * @param array $injectedClasses
+     */
     public function injectIntoCommandData($commandData, $injectedClasses)
     {
         $this->parameterInjection()->injectIntoCommandData($commandData, $injectedClasses);
+    }
+
+    /**
+     * Inject $input and $output into the command instance if it is set up to receive them.
+     *
+     * @param callable $commandCallback
+     * @param CommandData $commandData
+     */
+    protected function injectIntoCommandInstance($commandCallback, CommandData $commandData)
+    {
+        $commandInstance = $this->recoverObject($commandCallback);
+        if (!$commandInstance) {
+            return;
+        }
+
+        if ($commandInstance instanceof InputAwareInterface) {
+            $commandInstance->setInput($commandData->input());
+        }
+        if ($commandInstance instanceof OutputAwareInterface) {
+            $commandInstance->setInput($commandData->output());
+        }
+    }
+
+    /**
+     * If the command callback is a method of an object, return the object.
+     *
+     * @param callable $commandCallback
+     * @return object|bool
+     */
+    protected function recoverObject($commandCallback)
+    {
+        if (!is_array($commandCallback)) {
+            return false;
+        }
+
+        if (!is_object($commandCallback[0])) {
+            return false;
+        }
+
+        return $commandCallback[0];
     }
 }

--- a/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
+++ b/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
@@ -2,13 +2,14 @@
 
 namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
 
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Consolidation\AnnotatedCommand\InjectionHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Consolidation\AnnotatedCommand\AnnotatedCommand;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Call hooks

--- a/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
+++ b/src/Hooks/Dispatchers/CommandEventHookDispatcher.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
 
 /**
  * Call hooks
@@ -19,6 +20,14 @@ class CommandEventHookDispatcher extends HookDispatcher
      */
     public function callCommandEventHooks(ConsoleCommandEvent $event)
     {
+        $command = $event->getCommand();
+        $input = $event->getInput();
+        $output = $event->getOutput();
+
+        if ($command instanceof AnnotatedCommand) {
+            $command->injectIntoCommandfileInstance($input, $output);
+        }
+
         $hooks = [
             HookManager::PRE_COMMAND_EVENT,
             HookManager::COMMAND_EVENT,
@@ -30,6 +39,7 @@ class CommandEventHookDispatcher extends HookDispatcher
                 $commandEvent->dispatch($event, ConsoleEvents::COMMAND);
             }
             if (is_callable($commandEvent)) {
+                InjectionHelper::injectIntoCallbackObject($commandEvent, $input, $output);
                 $commandEvent($event);
             }
         }

--- a/src/Hooks/Dispatchers/InitializeHookDispatcher.php
+++ b/src/Hooks/Dispatchers/InitializeHookDispatcher.php
@@ -2,9 +2,10 @@
 
 namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
 
-use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Hooks\InitializeHookInterface;
+use Consolidation\AnnotatedCommand\InjectionHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 

--- a/src/Hooks/Dispatchers/InitializeHookDispatcher.php
+++ b/src/Hooks/Dispatchers/InitializeHookDispatcher.php
@@ -30,6 +30,7 @@ class InitializeHookDispatcher extends HookDispatcher implements InitializeHookI
 
     protected function callInitializeHook($provider, $input, AnnotationData $annotationData)
     {
+        InjectionHelper::injectIntoCallbackObject($provider, $input);
         if ($provider instanceof InitializeHookInterface) {
             return $provider->initialize($input, $annotationData);
         }

--- a/src/Hooks/Dispatchers/InteractHookDispatcher.php
+++ b/src/Hooks/Dispatchers/InteractHookDispatcher.php
@@ -5,6 +5,7 @@ namespace Consolidation\AnnotatedCommand\Hooks\Dispatchers;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Hooks\InteractorInterface;
+use Consolidation\AnnotatedCommand\InjectionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Hooks/Dispatchers/InteractHookDispatcher.php
+++ b/src/Hooks/Dispatchers/InteractHookDispatcher.php
@@ -31,6 +31,7 @@ class InteractHookDispatcher extends HookDispatcher
 
     protected function callInteractor($interactor, $input, $output, AnnotationData $annotationData)
     {
+        InjectionHelper::injectIntoCallbackObject($interactor, $input, $output);
         if ($interactor instanceof InteractorInterface) {
             return $interactor->interact($input, $output, $annotationData);
         }

--- a/src/Hooks/Dispatchers/ProcessResultHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ProcessResultHookDispatcher.php
@@ -6,6 +6,7 @@ use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Hooks\ProcessResultInterface;
+use Consolidation\AnnotatedCommand\InjectionHelper;
 
 /**
  * Call hooks

--- a/src/Hooks/Dispatchers/ProcessResultHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ProcessResultHookDispatcher.php
@@ -38,6 +38,7 @@ class ProcessResultHookDispatcher extends HookDispatcher implements ProcessResul
 
     protected function callProcessor($processor, $result, CommandData $commandData)
     {
+        InjectionHelper::injectIntoCallbackObject($processor, $commandData->input(), $commandData->output());
         $processed = null;
         if ($processor instanceof ProcessResultInterface) {
             $processed = $processor->process($result, $commandData);

--- a/src/Hooks/Dispatchers/ValidateHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ValidateHookDispatcher.php
@@ -7,6 +7,7 @@ use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandError;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Hooks\ValidatorInterface;
+use Consolidation\AnnotatedCommand\InjectionHelper;
 
 /**
  * Call hooks

--- a/src/Hooks/Dispatchers/ValidateHookDispatcher.php
+++ b/src/Hooks/Dispatchers/ValidateHookDispatcher.php
@@ -36,6 +36,7 @@ class ValidateHookDispatcher extends HookDispatcher implements ValidatorInterfac
 
     protected function callValidator($validator, CommandData $commandData)
     {
+        InjectionHelper::injectIntoCallbackObject($validator, $commandData->input(), $commandData->output());
         if ($validator instanceof ValidatorInterface) {
             return $validator->validate($commandData);
         }

--- a/src/InjectionHelper.php
+++ b/src/InjectionHelper.php
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Input\InputAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-public class InjectionHelper
+class InjectionHelper
 {
     /**
      * Inject $input and $output into the command instance if it is set up to receive them.
@@ -16,7 +16,7 @@ public class InjectionHelper
      */
     public static function injectIntoCallbackObject($callback, InputInterface $input, OutputInterface $output = null)
     {
-        $callbackObject = $this->recoverCallbackObject($callback);
+        $callbackObject = static::recoverCallbackObject($callback);
         if (!$callbackObject) {
             return;
         }

--- a/src/InjectionHelper.php
+++ b/src/InjectionHelper.php
@@ -1,0 +1,54 @@
+<?php
+namespace Consolidation\AnnotatedCommand;
+
+use Consolidation\AnnotatedCommand\Output\OutputAwareInterface;
+use Symfony\Component\Console\Input\InputAwareInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+public class InjectionHelper
+{
+    /**
+     * Inject $input and $output into the command instance if it is set up to receive them.
+     *
+     * @param Callable|object $callback
+     * @param OutputInterface $output
+     */
+    public static function injectIntoCallbackObject($callback, InputInterface $input, OutputInterface $output = null)
+    {
+        $callbackObject = $this->recoverCallbackObject($callback);
+        if (!$callbackObject) {
+            return;
+        }
+
+        if ($callbackObject instanceof InputAwareInterface) {
+            $callbackObject->setInput($input);
+        }
+        if (isset($output) && $callbackObject instanceof OutputAwareInterface) {
+            $callbackObject->setOutput($output);
+        }
+    }
+
+    /**
+     * If the command callback is a method of an object, return the object.
+     *
+     * @param Callable|object $callback
+     * @return object|bool
+     */
+    protected static function recoverCallbackObject($callback)
+    {
+        if (is_object($callback)) {
+            return $callback;
+        }
+
+        if (!is_array($callback)) {
+            return false;
+        }
+
+        if (!is_object($callback[0])) {
+            return false;
+        }
+
+        return $callback[0];
+    }
+}

--- a/src/Output/OutputAwareInterface.php
+++ b/src/Output/OutputAwareInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Provide OutputAwareInterface, not present in Symfony Console
+ */
+
+namespace Consolidation\AnnotatedCommand\Output;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface OutputAwareInterface
+{
+    /**
+     * Sets the Console Output.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public function setOutput(OutputInterface $output);
+}


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Robo command files are harder to test than they should be, because the DI container caches $input and $output and provides the cached value to the command object, which actually needs / wants the $input and $output parameters provided to the Symfony command object.

This PR re-injects the fresh values to ensure that the correct result is obtained.