### PR TITLE
Php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
 
 matrix:
   include:
-    - 'nightly'
     - php: 7.4
       env: 'DEPENDENCIES=highest'
     - php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
 
 matrix:
   include:
+    - 'nightly'
     - php: 7.4
       env: 'DEPENDENCIES=highest'
     - php: 7.4

--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -254,7 +254,7 @@ class CommandProcessor implements LoggerAwareInterface
         $result = false;
         try {
             $args = $this->parameterInjection()->args($commandData);
-            $result = call_user_func_array($commandCallback, $args);
+            $result = call_user_func_array($commandCallback, array_values($args));
         } catch (\Exception $e) {
             $result = $this->commandErrorForException($e);
         }


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Adds a feature
- [x] Has tests that cover changes

### Summary
Add php 8 to travis and changes second argument of call_user_func_array() from associative to indexed array. 
### Description
Before PHP 8 both types of arrays work the same but on PHP 8 associative arrays are interpreted as "named parameters". 
I am trying to fix what I find in my way of running robo 3 with php 8.
