### PR TITLE
Add @ignored-command annotation.

### DIFF
--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -153,6 +153,15 @@ EOT;
         $this->assertRunCommandViaApplicationEquals($command, $input, "Arg is test, options[help] is false");
     }
 
+    function testIgnoredCommand()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+
+        $commandList = $this->commandFactory->createCommandsFromClass($this->commandFileInstance);
+        $this->assertArrayNotHasKey('ignoredCommand', $commandList);
+    }
+
     function testOptionWithOptionalValue()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
@@ -308,6 +317,7 @@ EOT;
 
         $this->commandFactory->addCommandInfoAlterer(new ExampleCommandInfoAlterer());
 
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'myEcho');
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
 
         $annotationData = $command->getAnnotationData();

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -538,4 +538,11 @@ class ExampleCommandFile
     {
         return "Arg is $arg, options[help] is " . var_export($options['help'], true) . "\n";
     }
+
+    /**
+     * @ignored-command
+     */
+    public function ignoredCommand()
+    {
+    }
 }


### PR DESCRIPTION
Move the alter for command info to earlier moments of the life
of the object.

### Disposition
This pull request:

- [x] Adds a feature
- [x] Has tests that cover changes

### Summary
Add the concept of the @ignored-command annotation as a quick and handy way to remove a method to be recognized as a command.

### Description
Initially discussed here
https://github.com/consolidation/Robo/pull/987
As an additional change I moved the alter of the $commandInfo to the earliest moment possible. This has the potential to break things but I think it is pretty safe. This is needed for detecting later a dynamically added `@ignored-command` annotation. I plan to use a CommandInfoAlterer in Robo to add the annotations.

The confusing part was the `createCommandInfo` method as it seems to be only used by the tests and is some kind of alias for the `CommandInfo::create()` method. Its presence doesn't make much sense to me. 

Renamed `$classNameOrInstance` variables to `$commandFileInstance` as there was a bit of confusion with what should be passed to the methods. The case for passing just a class name doesn't seem to be in use or tested. 
