### PR TITLE
Add ability to ignore methods using regular expressions.

### DIFF
--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -162,6 +162,18 @@ EOT;
         $this->assertArrayNotHasKey('ignoredCommand', $commandList);
     }
 
+    function testIgnoredCommandByRegex()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+
+        $commandList = $this->commandFactory->createCommandsFromClass($this->commandFileInstance);
+        $this->assertArrayHasKey('ignoredCommandByRegex', $commandList);
+        $this->commandFactory->addIgnoredCommandsRegexp('/ignored.ommand.y.egex/');
+        $commandList = $this->commandFactory->createCommandsFromClass($this->commandFileInstance);
+        $this->assertArrayNotHasKey('ignoredCommandByRegex', $commandList);
+    }
+
     function testOptionWithOptionalValue()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -545,4 +545,8 @@ class ExampleCommandFile
     public function ignoredCommand()
     {
     }
+
+    public function ignoredCommandByRegex()
+    {
+    }
 }


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Adds a feature
- [x] Has tests that cover changes

### Summary
Add a list of regular expressions to AnnotatedCommandFactory that are going to be matched against the method names of the class with the commands. When the method name matches that method won't be considered a command.

### Description
The discussion started here:
https://github.com/consolidation/Robo/pull/987
I deprecated a couple of methods and made non-static protected copies of them.
