### PR TITLE
Symfony 5.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.1.3",
         "consolidation/output-formatters": "^4.1.1",
         "psr/log": "^1|^2",
-        "symfony/console": "^4.4.8|~5.1.0",
+        "symfony/console": "^4.4.8|^5.2",
         "symfony/event-dispatcher": "^4.4.8|^5",
         "symfony/finder": "^4.4.8|^5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2670b3bce2706a49ebeda9dd41ede93",
+    "content-hash": "d852188ca4121436d91620ac93acb3b6",
     "packages": [
         {
             "name": "consolidation/output-formatters",
@@ -278,16 +278,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.11",
+            "version": "v5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d9a267b621c5082e0a6c659d73633b6fd28a8a08"
+                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d9a267b621c5082e0a6c659d73633b6fd28a8a08",
-                "reference": "d9a267b621c5082e0a6c659d73633b6fd28a8a08",
+                "url": "https://api.github.com/repos/symfony/console/zipball/938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
+                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
                 "shasum": ""
             },
             "require": {
@@ -348,8 +348,14 @@
             ],
             "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.1.11"
+                "source": "https://github.com/symfony/console/tree/v5.2.5"
             },
             "funding": [
                 {
@@ -365,7 +371,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:01:46+00:00"
+            "time": "2021-03-06T13:42:15+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1707,16 +1713,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -1768,9 +1774,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2071,16 +2077,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.14",
+            "version": "8.5.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c25f79895d27b6ecd5abfa63de1606b786a461a3"
+                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c25f79895d27b6ecd5abfa63de1606b786a461a3",
-                "reference": "c25f79895d27b6ecd5abfa63de1606b786a461a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
+                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
                 "shasum": ""
             },
             "require": {
@@ -2152,7 +2158,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.14"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.15"
             },
             "funding": [
                 {
@@ -2164,7 +2170,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-17T07:37:30+00:00"
+            "time": "2021-03-17T07:27:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -424,7 +424,7 @@ EOT;
         $this->assertRunCommandViaApplicationEquals($command, $input, 'We hold these truths to be self-evident, that all men are created equal, that they are endowed by their Creator with certain unalienable Rights, that among these are Life, Liberty and the pursuit of Happiness.');
 
         $input = new StringInput('cat:too ' . $selfEvidentPath);
-        $this->assertRunCommandViaApplicationContains($command, $input, ['Too many arguments'], 1);
+        $this->assertRunCommandViaApplicationContains($command, $input, ['No arguments expected'], 1);
     }
 
     function testCatNoDICommand()
@@ -457,7 +457,7 @@ EOT;
         $this->assertRunCommandViaApplicationEquals($command, $input, 'We hold these truths to be self-evident, that all men are created equal, that they are endowed by their Creator with certain unalienable Rights, that among these are Life, Liberty and the pursuit of Happiness.');
 
         $input = new StringInput('cat:no-di ' . $selfEvidentPath);
-        $this->assertRunCommandViaApplicationContains($command, $input, ['Too many arguments'], 1);
+        $this->assertRunCommandViaApplicationContains($command, $input, ['No arguments expected'], 1);
     }
 
     function testJoinCommandHelp()

--- a/tests/HelpTest.php
+++ b/tests/HelpTest.php
@@ -138,7 +138,7 @@ class HelpTest extends TestCase
       <defaults/>
     </option>
     <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-      <description>Display this help message</description>
+      <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>\n
     </option>
     <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
       <description>Do not output any message</description>
@@ -235,7 +235,7 @@ EOT;
             "accept_value": "0",
             "is_value_required": "0",
             "is_multiple": "0",
-            "description": "Display this help message"
+            "description": "Display help for the given command. When no command is given display help for the list command"
         },
         "quiet": {
             "name": "--quiet",


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [x] Adds a feature
- [x] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Fixes for `symfony/console` 5.2+

### Description
This fixes #217 

However, I need your input regarding the following points:

* while I could get the two tests working, the hook test still fails with `The "french" option does not exist.`
  * https://github.com/consolidation/annotated-command/blob/9d0d55025ccaeffaa31c07cbe135c1b90e7cc28f/tests/FullStackTest.php#L173
  * I dug deep into the hook code, debugged tests etc. but could not get to the point why it does not parse the option correctly in 5.2+. Any hints?
* I am unsure how to handle Symfony version compatibility, since now the tests fail with 5.1.11 (the version before this change)

