### PR TITLE
Fix bc break with simple option parameters

### DIFF
--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -100,6 +100,11 @@ class CommandInfo
     protected $parameterMap = [];
 
     /**
+     * @var bool
+     */
+    protected $simpleOptionParametersAllowed = false;
+
+    /**
      * Create a new CommandInfo class for a particular method of a class.
      *
      * @param string|mixed $classNameOrInstance The name of a class, or an
@@ -155,7 +160,9 @@ class CommandInfo
         // `$options = ['name' => 'default'], and arguments will be everything else.
         // When we process the annotations / attributes, if we find an "option" which
         // appears in the 'arguments' section, then we will move it.
-        $this->options = new DefaultsWithDescriptions($this->determineOptionsFromParameters(), false);
+        $optionsFromParameters = $this->determineOptionsFromParameters();
+        $this->simpleOptionParametersAllowed = empty($optionsFromParameters);
+        $this->options = new DefaultsWithDescriptions($optionsFromParameters, false);
         $this->arguments = $this->determineAgumentClassifications();
     }
 
@@ -625,7 +632,7 @@ class CommandInfo
     public function addOptionDescription($name, $description)
     {
         $variableName = $this->findMatchingOption($name);
-        if ($this->arguments()->exists($variableName)) {
+        if ($this->simpleOptionParametersAllowed && $this->arguments()->exists($variableName)) {
             $existingArg = $this->arguments()->removeMatching($variableName);
             // One of our parameters is an option, not an argument. Flag it so that we can inject the right value when needed.
             $this->parameterMap[$variableName] = true;


### PR DESCRIPTION
Only allow simple option parameters if the final options-array parameter is NOT used (fix bc break).

See https://github.com/drush-ops/drush/issues/4813 for details.