### PR TITLE
Fix #234. Less parsing by ignoring Traits and IO.php 

### DIFF
--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -266,7 +266,8 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
             get_class_methods($commandFileInstance) ?: [],
             function ($m) use ($commandFileInstance) {
                 $reflectionMethod = new \ReflectionMethod($commandFileInstance, $m);
-                return !$reflectionMethod->isStatic() && !preg_match('#^_#', $m);
+                $name = $reflectionMethod->getFileName();
+                return !$reflectionMethod->isStatic() && !preg_match('#^_#', $m) && basename($name) !== 'IO.php' && strpos($name, 'Trait') === false;
             }
         );
 


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Avoid repeated parsing of methods unlikely to contain annotations.
