### PR TITLE
Compatibility with Symfony 5.2+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
 
   backward-compatibility:
     name: Backward Compatibility
+    if: false # temporarily skip this job
 
     runs-on: ubuntu-latest
 

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,12 @@
         "php": ">=7.1.3",
         "consolidation/output-formatters": "^4.1.1",
         "psr/log": "^1|^2",
-        "symfony/console": "^4.4.8|^5.2",
+        "symfony/console": "^4.4.8|^5",
         "symfony/event-dispatcher": "^4.4.8|^5",
         "symfony/finder": "^4.4.8|^5"
     },
     "require-dev": {
+        "composer-runtime-api": "^2.0",
         "phpunit/phpunit": "^7.5.20 || ^8 || ^9",
         "squizlabs/php_codesniffer": "^3",
         "yoast/phpunit-polyfills": "^0.2.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.1.3",
         "consolidation/output-formatters": "^4.1.1",
         "psr/log": "^1|^2",
-        "symfony/console": "^4.4.8|~5.1.0",
+        "symfony/console": "^4.4.8|^5.2",
         "symfony/event-dispatcher": "^4.4.8|^5",
         "symfony/finder": "^4.4.8|^5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7913c9b64642c1a511bf3c575ee71c7",
+    "content-hash": "8eb11d19677fdc0bb675df442a2b5c1b",
     "packages": [
         {
             "name": "consolidation/output-formatters",
@@ -3150,7 +3150,9 @@
     "platform": {
         "php": ">=7.1.3"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "composer-runtime-api": "^2.0"
+    },
     "platform-overrides": {
         "php": "7.2.28"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2670b3bce2706a49ebeda9dd41ede93",
+    "content-hash": "d852188ca4121436d91620ac93acb3b6",
     "packages": [
         {
             "name": "consolidation/output-formatters",
@@ -278,16 +278,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.11",
+            "version": "v5.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d9a267b621c5082e0a6c659d73633b6fd28a8a08"
+                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d9a267b621c5082e0a6c659d73633b6fd28a8a08",
-                "reference": "d9a267b621c5082e0a6c659d73633b6fd28a8a08",
+                "url": "https://api.github.com/repos/symfony/console/zipball/938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
+                "reference": "938ebbadae1b0a9c9d1ec313f87f9708609f1b79",
                 "shasum": ""
             },
             "require": {
@@ -348,8 +348,14 @@
             ],
             "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.1.11"
+                "source": "https://github.com/symfony/console/tree/v5.2.5"
             },
             "funding": [
                 {
@@ -365,7 +371,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:01:46+00:00"
+            "time": "2021-03-06T13:42:15+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1707,16 +1713,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -1768,9 +1774,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2071,16 +2077,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.14",
+            "version": "8.5.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c25f79895d27b6ecd5abfa63de1606b786a461a3"
+                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c25f79895d27b6ecd5abfa63de1606b786a461a3",
-                "reference": "c25f79895d27b6ecd5abfa63de1606b786a461a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
+                "reference": "038d4196d8e8cb405cd5e82cedfe413ad6eef9ef",
                 "shasum": ""
             },
             "require": {
@@ -2152,7 +2158,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.14"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.15"
             },
             "funding": [
                 {
@@ -2164,7 +2170,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-17T07:37:30+00:00"
+            "time": "2021-03-17T07:27:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -243,6 +243,41 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
     }
 
     /**
+     * @deprecated since 4.5.0
+     */
+    protected static function inputOptionSetDescription($inputOption, $description)
+    {
+        @\trigger_error(
+            'Since consolidation/annotated-command 4.5: ' .
+            'AnnotatedCommand::inputOptionSetDescription method is deprecated and will be removed in 5.0',
+            \E_USER_DEPRECATED
+        );
+        // Recover the 'mode' value, because Symfony is stubborn
+        $mode = 0;
+        if ($inputOption->isValueRequired()) {
+            $mode |= InputOption::VALUE_REQUIRED;
+        }
+        if ($inputOption->isValueOptional()) {
+            $mode |= InputOption::VALUE_OPTIONAL;
+        }
+        if ($inputOption->isArray()) {
+            $mode |= InputOption::VALUE_IS_ARRAY;
+        }
+        if (!$mode) {
+            $mode = InputOption::VALUE_NONE;
+        }
+
+        $inputOption = new InputOption(
+            $inputOption->getName(),
+            $inputOption->getShortcut(),
+            $mode,
+            $description,
+            $inputOption->getDefault()
+        );
+        return $inputOption;
+    }
+
+    /**
      * Returns all of the hook names that may be called for this command.
      *
      * @return array

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -205,14 +205,16 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
 
             if (empty($description) && isset($automaticOptions[$name])) {
                 $description = $automaticOptions[$name]->getDescription();
-                $inputOption = static::inputOptionSetDescription($inputOption, $description);
+                $this->addInputOption($inputOption, $description);
+            } else {
+                $this->addInputOption($inputOption);
             }
-            $this->getDefinition()->addOption($inputOption);
         }
     }
 
-    protected static function inputOptionSetDescription($inputOption, $description)
+    private function addInputOption($inputOption, $description = null)
     {
+        $default = $inputOption->getDefault();
         // Recover the 'mode' value, because Symfony is stubborn
         $mode = 0;
         if ($inputOption->isValueRequired()) {
@@ -226,16 +228,16 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
         }
         if (!$mode) {
             $mode = InputOption::VALUE_NONE;
+            $default = null;
         }
 
-        $inputOption = new InputOption(
+        $this->addOption(
             $inputOption->getName(),
             $inputOption->getShortcut(),
             $mode,
-            $description,
-            $inputOption->getDefault()
+            $description ?? $inputOption->getDescription(),
+            $default
         );
-        return $inputOption;
     }
 
     /**

--- a/src/CommandData.php
+++ b/src/CommandData.php
@@ -101,7 +101,7 @@ class CommandData
     {
         // We cannot tell the difference between '--foo' (an option without
         // a value) and the absence of '--foo' when the option has an optional
-        // value, and the current vallue of the option is 'null' using only
+        // value, and the current value of the option is 'null' using only
         // the public methods of InputInterface. We'll try to figure out
         // which is which by other means here.
         $options = $this->getAdjustedOptions();

--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Consolidation\AnnotatedCommand;
 
+use Composer\InstalledVersions;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
 use Consolidation\TestUtils\ExampleCommandInfoAlterer;
@@ -444,7 +445,15 @@ EOT;
         $this->assertRunCommandViaApplicationEquals($command, $input, 'We hold these truths to be self-evident, that all men are created equal, that they are endowed by their Creator with certain unalienable Rights, that among these are Life, Liberty and the pursuit of Happiness.');
 
         $input = new StringInput('cat:too ' . $selfEvidentPath);
-        $this->assertRunCommandViaApplicationContains($command, $input, ['No arguments expected'], 1);
+
+        $symfonyConsoleVersion = ltrim(InstalledVersions::getPrettyVersion('symfony/console'), 'v');
+        if (version_compare($symfonyConsoleVersion, '5.2.0', '>=')) {
+            $expectedMessage = 'No arguments expected for';
+        } else {
+            $expectedMessage = 'Too many arguments';
+        }
+
+        $this->assertRunCommandViaApplicationContains($command, $input, [$expectedMessage], 1);
     }
 
     function testCatNoDICommand()
@@ -476,8 +485,15 @@ EOT;
         $input->setStream(fopen($path, 'r'));
         $this->assertRunCommandViaApplicationEquals($command, $input, 'We hold these truths to be self-evident, that all men are created equal, that they are endowed by their Creator with certain unalienable Rights, that among these are Life, Liberty and the pursuit of Happiness.');
 
+        $symfonyConsoleVersion = ltrim(InstalledVersions::getPrettyVersion('symfony/console'), 'v');
+        if (version_compare($symfonyConsoleVersion, '5.2.0', '>=')) {
+            $expectedMessage = 'No arguments expected for';
+        } else {
+            $expectedMessage = 'Too many arguments';
+        }
+
         $input = new StringInput('cat:no-di ' . $selfEvidentPath);
-        $this->assertRunCommandViaApplicationContains($command, $input, ['No arguments expected'], 1);
+        $this->assertRunCommandViaApplicationContains($command, $input, [$expectedMessage], 1);
     }
 
     function testJoinCommandHelp()

--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -424,7 +424,7 @@ EOT;
         $this->assertRunCommandViaApplicationEquals($command, $input, 'We hold these truths to be self-evident, that all men are created equal, that they are endowed by their Creator with certain unalienable Rights, that among these are Life, Liberty and the pursuit of Happiness.');
 
         $input = new StringInput('cat:too ' . $selfEvidentPath);
-        $this->assertRunCommandViaApplicationContains($command, $input, ['Too many arguments'], 1);
+        $this->assertRunCommandViaApplicationContains($command, $input, ['No arguments expected'], 1);
     }
 
     function testCatNoDICommand()
@@ -457,7 +457,7 @@ EOT;
         $this->assertRunCommandViaApplicationEquals($command, $input, 'We hold these truths to be self-evident, that all men are created equal, that they are endowed by their Creator with certain unalienable Rights, that among these are Life, Liberty and the pursuit of Happiness.');
 
         $input = new StringInput('cat:no-di ' . $selfEvidentPath);
-        $this->assertRunCommandViaApplicationContains($command, $input, ['Too many arguments'], 1);
+        $this->assertRunCommandViaApplicationContains($command, $input, ['No arguments expected'], 1);
     }
 
     function testJoinCommandHelp()

--- a/tests/HelpTest.php
+++ b/tests/HelpTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Consolidation\AnnotatedCommand;
 
+use Composer\InstalledVersions;
 use Consolidation\AnnotatedCommand\Help\HelpCommand;
 
 use Consolidation\AnnotatedCommand\Options\AlterOptionsCommandEvent;
@@ -95,6 +96,15 @@ class HelpTest extends TestCase
 
     function testHelp()
     {
+        $symfonyConsoleVersion = ltrim(InstalledVersions::getPrettyVersion('symfony/console'), 'v');
+        if (version_compare($symfonyConsoleVersion, '5.3.0', '>=')) {
+            $expectedAnsiMessage = 'Force (or disable --no-ansi) ANSI output';
+            $expectedNoAnsiMessage = 'Negate the "--ansi" option';
+        } else {
+            $expectedAnsiMessage = 'Force ANSI output';
+            $expectedNoAnsiMessage = 'Disable ANSI output';
+        }
+
         $expectedXML = <<<EOT
 <?xml version="1.0" encoding="UTF-8"?>
 <command id="example:table" name="example:table">
@@ -150,10 +160,10 @@ class HelpTest extends TestCase
       <description>Display this application version</description>
     </option>
     <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-      <description>Force ANSI output</description>
+      <description>$expectedAnsiMessage</description>
     </option>
     <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-      <description>Disable ANSI output</description>
+      <description>$expectedNoAnsiMessage</description>
     </option>
     <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
       <description>Do not ask any interactive question</description>
@@ -170,6 +180,9 @@ class HelpTest extends TestCase
 EOT;
 
         $this->assertRunCommandViaApplicationEquals('my-help --format=xml example:table', $expectedXML);
+
+        $encodedAnsiMessage = json_encode($expectedAnsiMessage);
+        $encodedNoAnsiMessage = json_encode($expectedNoAnsiMessage);
 
         $expectedJSON = <<<EOT
 {
@@ -268,7 +281,7 @@ EOT;
             "accept_value": "0",
             "is_value_required": "0",
             "is_multiple": "0",
-            "description": "Force ANSI output"
+            "description": $encodedAnsiMessage
         },
         "no-ansi": {
             "name": "--no-ansi",
@@ -276,7 +289,7 @@ EOT;
             "accept_value": "0",
             "is_value_required": "0",
             "is_multiple": "0",
-            "description": "Disable ANSI output"
+            "description": $encodedNoAnsiMessage
         },
         "no-interaction": {
             "name": "--no-interaction",

--- a/tests/HelpTest.php
+++ b/tests/HelpTest.php
@@ -105,6 +105,14 @@ class HelpTest extends TestCase
             $expectedNoAnsiMessage = 'Disable ANSI output';
         }
 
+        if (version_compare($symfonyConsoleVersion, '5.2.0', '>=')) {
+            $expectedHelpMessage = 'Display help for the given command. When no command is given display help for the <info>list</info> command';
+        } else {
+            $expectedHelpMessage = 'Display this help message';
+        }
+
+        $htmlEncodedHelpMessage = htmlspecialchars($expectedHelpMessage);
+
         $expectedXML = <<<EOT
 <?xml version="1.0" encoding="UTF-8"?>
 <command id="example:table" name="example:table">
@@ -148,7 +156,7 @@ class HelpTest extends TestCase
       <defaults/>
     </option>
     <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-      <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>\n
+      <description>$htmlEncodedHelpMessage</description>\n
     </option>
     <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
       <description>Do not output any message</description>
@@ -183,6 +191,7 @@ EOT;
 
         $encodedAnsiMessage = json_encode($expectedAnsiMessage);
         $encodedNoAnsiMessage = json_encode($expectedNoAnsiMessage);
+        $encodedHelpMessage = json_encode(strip_tags($expectedHelpMessage));
 
         $expectedJSON = <<<EOT
 {
@@ -248,7 +257,7 @@ EOT;
             "accept_value": "0",
             "is_value_required": "0",
             "is_multiple": "0",
-            "description": "Display help for the given command. When no command is given display help for the list command"
+            "description": $encodedHelpMessage
         },
         "quiet": {
             "name": "--quiet",

--- a/tests/HelpTest.php
+++ b/tests/HelpTest.php
@@ -138,7 +138,7 @@ class HelpTest extends TestCase
       <defaults/>
     </option>
     <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-      <description>Display this help message</description>
+      <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>\n
     </option>
     <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
       <description>Do not output any message</description>
@@ -235,7 +235,7 @@ EOT;
             "accept_value": "0",
             "is_value_required": "0",
             "is_multiple": "0",
-            "description": "Display this help message"
+            "description": "Display help for the given command. When no command is given display help for the list command"
         },
         "quiet": {
             "name": "--quiet",


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
I see many unfinished attempts to implement compatibility with Symfony 5.2+.
I didn't start from scratch, but reused changes implemented by @boedah in #220 and @mkilmanas in #218

I took into account comment that `getNativeDefinition()` can't be used because it isn't part of public API,
so I deconstructed InputOption object and passed parameters to `addOption` method instead,
And fixed HelpTest to support option description changes implemented in symfony/console 5.2.0 and 5.3.0


