### PR TITLE
Do not pass null to Symfony Command methods

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -125,8 +125,8 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
 
     public function setCommandInfo($commandInfo)
     {
-        $this->setDescription($commandInfo->getDescription());
-        $this->setHelp($commandInfo->getHelp());
+        $this->setDescription($commandInfo->getDescription() ?: '');
+        $this->setHelp($commandInfo->getHelp() ?: '');
         $this->setAliases($commandInfo->getAliases());
         $this->setAnnotationData($commandInfo->getAnnotations());
         $this->setTopics($commandInfo->getTopics());


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Forward-ported from 4.x branch