### PR TITLE
PHP 8.2 compatibility: dynamic properties are deprecated

### DIFF
--- a/src/ParameterInjection.php
+++ b/src/ParameterInjection.php
@@ -7,6 +7,8 @@ namespace Consolidation\AnnotatedCommand;
  */
 class ParameterInjection implements ParameterInjector
 {
+    protected $injectors = [];
+
     public function __construct()
     {
         $this->register('Symfony\Component\Console\Input\InputInterface', $this);


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug https://php.watch/versions/8.2/dynamic-properties-deprecated

### Summary
properties should be defined

### Description
May need more changes but I see no more in logs at least

Ref https://github.com/drush-ops/drush/issues/5168