### PR TITLE
Stop loading commands from inherited classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 on:
   pull_request:
     branches:
-      - main
+      - 5.x
       - 4.x
   push:
     branches:

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,7 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true,
-        "allow-plugins": {
-            "ocramius/package-versions": true
-        }
+        "sort-packages": true
     },
     "scripts": {
         "cs": "phpcs --standard=PSR2 -n src",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,10 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "ocramius/package-versions": true
+        }
     },
     "scripts": {
         "cs": "phpcs --standard=PSR2 -n src",

--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -281,11 +281,15 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
 
         // Ignore special functions, such as __construct and __call, which
         // can never be commands.
+        $commandClass = get_class($commandFileInstance);
         $commandMethodNames = array_filter(
             get_class_methods($commandFileInstance) ?: [],
-            function ($m) use ($commandFileInstance) {
+            function ($m) use ($commandFileInstance, $commandClass) {
                 $reflectionMethod = new \ReflectionMethod($commandFileInstance, $m);
                 $name = $reflectionMethod->getFileName();
+                if ($reflectionMethod->getDeclaringClass()->getName() !== $commandClass) {
+                    return false;
+                }
                 if ($reflectionMethod->isStatic() || preg_match('#^_#', $m)) {
                     return false;
                 }


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

_Neither a bug or a feature, more like an improvement._

### Summary
As discussed in https://github.com/drush-ops/drush/issues/5260#issuecomment-1282186102, if a command class extends another command class, the commands of the extended class should not be registered.
