### PR TITLE
Support completion for command options and arguments (v2)

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -9,6 +9,8 @@ use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Consolidation\AnnotatedCommand\State\State;
 use Consolidation\AnnotatedCommand\State\StateHelper;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,6 +35,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class AnnotatedCommand extends Command implements HelpDocumentAlter
 {
     protected $commandCallback;
+    protected $completionCallback;
     protected $commandProcessor;
     protected $annotationData;
     protected $examples = [];
@@ -67,6 +70,12 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
     public function setCommandCallback($commandCallback)
     {
         $this->commandCallback = $commandCallback;
+        return $this;
+    }
+
+    public function setCompletionCallback($completionCallback)
+    {
+        $this->completionCallback = $completionCallback;
         return $this;
     }
 
@@ -297,6 +306,16 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
             $this->getNames(),
             $this->annotationData
         );
+    }
+
+    /**
+     * Route a completion request to the specified Callable if available.
+     */
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if (is_callable($this->completionCallback)) {
+            call_user_func($this->completionCallback, $input, $suggestions);
+        }
     }
 
     public function optionsHookForHookAnnotations($commandInfoList)

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -166,6 +166,11 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
         }
     }
 
+    public function getCompletionCallback()
+    {
+        return $this->completionCallback;
+    }
+
     public function helpAlter(\DomDocument $originalDom)
     {
         return HelpDocumentBuilder::alter($originalDom, $this);

--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -497,6 +497,11 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
         $command = new AnnotatedCommand($commandInfo->getName());
         $commandCallback = [$commandFileInstance, $commandInfo->getMethodName()];
         $command->setCommandCallback($commandCallback);
+        $completionCallback = null;
+        if ($annotation = $commandInfo->getAnnotation('complete')) {
+            $completionCallback = is_callable($annotation) ?: [$commandFileInstance, $annotation];
+        }
+        $command->setCompletionCallback($completionCallback);
         $command->setCommandProcessor($this->commandProcessor);
         $command->setCommandInfo($commandInfo);
         $automaticOptions = $this->callAutomaticOptionsProviders($commandInfo);

--- a/src/Attributes/Complete.php
+++ b/src/Attributes/Complete.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Attributes;
+
+use Attribute;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Complete
+{
+    /**
+     * @param $method_or_callable
+     *   A method in the command class or Callable that provides argument completion.
+     */
+    public function __construct(
+        public string $method_name_or_callable,
+    ) {
+    }
+
+    public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
+    {
+        $args = $attribute->getArguments();
+        $commandInfo->addAnnotation('complete', $args['method_name_or_callable']);
+    }
+}

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -79,7 +79,7 @@ class AttributesCommandFactoryTest extends TestCase
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;
         $this->commandFactory = new AnnotatedCommandFactory();
-        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'test:test:arithmatic');
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'test:arithmatic');
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
         $this->assertIsCallable($command->getCompletionCallback());
     }

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -79,7 +79,7 @@ class AttributesCommandFactoryTest extends TestCase
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;
         $this->commandFactory = new AnnotatedCommandFactory();
-        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'test:arithmatic');
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'testArithmatic');
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
         $this->assertIsCallable($command->getCompletionCallback());
     }

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -72,6 +72,18 @@ class AttributesCommandFactoryTest extends TestCase
         $this->assertEquals(RowsOfFields::class, $command->getReturnType());
     }
 
+    /**
+     * @requires PHP >= 8.0
+     */
+    function testArithmeticCommand()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'test:arithmetic');
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+        $this->assertIsCallable($command->getCompletionCallback());
+    }
+
     function assertRunCommandViaApplicationEquals($command, $input, $expectedOutput, $expectedStatusCode = 0)
     {
         list($statusCode, $commandOutput) = $this->runCommandViaApplication($command, $input);

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -79,7 +79,7 @@ class AttributesCommandFactoryTest extends TestCase
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;
         $this->commandFactory = new AnnotatedCommandFactory();
-        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'test:arithmetic');
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'test:test:arithmatic');
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
         $this->assertIsCallable($command->getCompletionCallback());
     }

--- a/tests/src/ExampleAttributesCommandFile.php
+++ b/tests/src/ExampleAttributesCommandFile.php
@@ -4,6 +4,8 @@ namespace Consolidation\TestUtils;
 use Consolidation\AnnotatedCommand\Attributes as CLI;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 
 /**
  * Test file used in the Annotation Factory tests.  It is also
@@ -61,6 +63,7 @@ class ExampleAttributesCommandFile
     #[CLI\Argument(name: 'two', description: 'The other number to add.')]
     #[CLI\Option(name: 'negate', description: 'Whether or not the result should be negated.')]
     #[CLI\Usage(name: '2 2 --negate', description: 'Add two plus two and then negate.')]
+    #[CLI\Complete(method_name_or_callable: 'testArithmaticComplete')]
     #[CLI\Misc(data: ['dup' => ['one', 'two']])]
     public function testArithmatic($one, $two = 2, array $options = ['negate' => false, 'unused' => 'bob'])
     {
@@ -93,5 +96,15 @@ class ExampleAttributesCommandFile
             ['Cardinal' => 'red'],
         ];
         return new RowsOfFields($rows);
+    }
+
+    /*
+     * An argument completion callback.
+     */
+    protected function testArithmaticComplete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('one') || $input->mustSuggestArgumentValuesFor('two')) {
+            $suggestions->suggestValues(range(0, 9));
+        }
     }
 }

--- a/tests/src/ExampleAttributesCommandFile.php
+++ b/tests/src/ExampleAttributesCommandFile.php
@@ -101,7 +101,7 @@ class ExampleAttributesCommandFile
     /*
      * An argument completion callback.
      */
-    protected function testArithmaticComplete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    public function testArithmaticComplete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
         if ($input->mustSuggestArgumentValuesFor('one') || $input->mustSuggestArgumentValuesFor('two')) {
             $suggestions->suggestValues(range(0, 9));


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Support Symfony Console 5.4+ completion. Also see https://github.com/drush-ops/drush/pull/5097