### PR TITLE
Use Attributes to set suggestedValues for arg/option completion

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -221,10 +221,14 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
             $description = $inputOption->getDescription();
 
             if (empty($description) && isset($automaticOptions[$name])) {
+                // Unfortunately, Console forces us too construct a new InputOption to set a description.
                 $description = $automaticOptions[$name]->getDescription();
                 $this->addInputOption($inputOption, $description);
             } else {
-                $this->addInputOption($inputOption);
+                if ($native = $this->getNativeDefinition()) {
+                    $native->addOption($inputOption);
+                }
+                $this->getDefinition()->addOption($inputOption);
             }
         }
     }

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -248,18 +248,22 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
             $default = null;
         }
 
-        // Alas, Symfony provides no accessor.
-        $class = new \ReflectionClass($inputOption);
-        $property = $class->getProperty("suggestedValues");
-        $property->setAccessible(true);
-
+        $suggestedValues = [];
+        // Symfony 6.1+ feature https://symfony.com/blog/new-in-symfony-6-1-improved-console-autocompletion#completion-values-in-input-definitions
+        if (property_exists($inputOption, 'suggestedValues')) {
+            // Alas, Symfony provides no accessor.
+            $class = new \ReflectionClass($inputOption);
+            $property = $class->getProperty('suggestedValues');
+            $property->setAccessible(true);
+            $suggestedValues = $property->getValue($inputOption);
+        }
         $this->addOption(
             $inputOption->getName(),
             $inputOption->getShortcut(),
             $mode,
             $description ?? $inputOption->getDescription(),
             $default,
-            $property->getValue($inputOption)
+            $suggestedValues
         );
     }
 

--- a/src/Attributes/Argument.php
+++ b/src/Attributes/Argument.php
@@ -13,16 +13,19 @@ class Argument
      *   The name of the argument.
      * @param $description
      *   A one line description.
+     * @param $suggestedValues
+     *   An array of suggestions or a Closure which gets them. See https://symfony.com/blog/new-in-symfony-6-1-improved-console-autocompletion#completion-values-in-input-definitions.
      */
     public function __construct(
         public string $name,
-        public string $description
+        public string $description,
+        public array|string $suggestedValues = []
     ) {
     }
 
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
         $args = $attribute->getArguments();
-        $commandInfo->addArgumentDescription($args['name'], @$args['description']);
+        $commandInfo->addArgumentDescription($args['name'], @$args['description'], @$args['suggestedValues']);
     }
 }

--- a/src/Attributes/Argument.php
+++ b/src/Attributes/Argument.php
@@ -19,7 +19,7 @@ class Argument
     public function __construct(
         public string $name,
         public string $description,
-        public array|string $suggestedValues = []
+        public array|\Closure $suggestedValues = []
     ) {
     }
 

--- a/src/Attributes/Option.php
+++ b/src/Attributes/Option.php
@@ -13,16 +13,19 @@ class Option
      *   The name of the option.
      * @param $description
      *   A one line description.
+     * @param $suggestedValues
+     *   An array of suggestions or a Closure which gets them. See https://symfony.com/blog/new-in-symfony-6-1-improved-console-autocompletion#completion-values-in-input-definitions.
      */
     public function __construct(
         public string $name,
-        public string $description
+        public string $description,
+        public array|\Closure $suggestedValues = []
     ) {
     }
 
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
         $args = $attribute->getArguments();
-        $commandInfo->addOptionDescription($args['name'], @$args['description']);
+        $commandInfo->addOptionDescription($args['name'], @$args['description'], @$args['suggestedValues']);
     }
 }

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -645,7 +645,7 @@ class CommandInfo
     protected function addOptionOrArgumentDescription(DefaultsWithDescriptions $set, $variableName, $description, $suggestedValues = [])
     {
         list($description, $defaultValue) = $this->splitOutDefault($description);
-        $set->add($variableName, $description,null, $suggestedValues);
+        $set->add($variableName, $description, null, $suggestedValues);
         if ($defaultValue !== null) {
             $set->setDefaultValue($variableName, $defaultValue);
         }

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -565,6 +565,7 @@ class CommandInfo
         $opts = $this->options()->getValues();
         foreach ($opts as $name => $defaultValue) {
             $description = $this->options()->getDescription($name);
+            $suggestedValues = $this->options()->getSuggestedValues($name);
 
             $fullName = $name;
             $shortcut = '';
@@ -584,7 +585,7 @@ class CommandInfo
             if ($defaultValue === false) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_NONE, $description);
             } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {
-                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description);
+                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description, null, $suggestedValues);
             } elseif (is_array($defaultValue)) {
                 $optionality = count($defaultValue) ? InputOption::VALUE_OPTIONAL : InputOption::VALUE_REQUIRED;
                 $explicitOptions[$fullName] = new InputOption(
@@ -592,10 +593,11 @@ class CommandInfo
                     $shortcut,
                     InputOption::VALUE_IS_ARRAY | $optionality,
                     $description,
-                    count($defaultValue) ? $defaultValue : null
+                    count($defaultValue) ? $defaultValue : null,
+                    $suggestedValues
                 );
             } else {
-                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_OPTIONAL, $description, $defaultValue);
+                $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_OPTIONAL, $description, $defaultValue, $suggestedValues);
             }
         }
 
@@ -624,12 +626,12 @@ class CommandInfo
         return $this->findOptionAmongAlternatives($optionName);
     }
 
-    public function addArgumentDescription($name, $description)
+    public function addArgumentDescription($name, $description, $suggestions = [])
     {
-        $this->addOptionOrArgumentDescription($this->arguments(), $name, $description);
+        $this->addOptionOrArgumentDescription($this->arguments(), $name, $description, $suggestions);
     }
 
-    public function addOptionDescription($name, $description)
+    public function addOptionDescription($name, $description, $suggestedValues = [])
     {
         $variableName = $this->findMatchingOption($name);
         if ($this->simpleOptionParametersAllowed && $this->arguments()->exists($variableName)) {
@@ -637,13 +639,13 @@ class CommandInfo
             // One of our parameters is an option, not an argument. Flag it so that we can inject the right value when needed.
             $this->parameterMap[$variableName] = true;
         }
-        $this->addOptionOrArgumentDescription($this->options(), $variableName, $description);
+        $this->addOptionOrArgumentDescription($this->options(), $variableName, $description, $suggestedValues);
     }
 
-    protected function addOptionOrArgumentDescription(DefaultsWithDescriptions $set, $variableName, $description)
+    protected function addOptionOrArgumentDescription(DefaultsWithDescriptions $set, $variableName, $description, $suggestedValues = [])
     {
         list($description, $defaultValue) = $this->splitOutDefault($description);
-        $set->add($variableName, $description);
+        $set->add($variableName, $description,null, $suggestedValues);
         if ($defaultValue !== null) {
             $set->setDefaultValue($variableName, $defaultValue);
         }

--- a/src/Parser/DefaultsWithDescriptions.php
+++ b/src/Parser/DefaultsWithDescriptions.php
@@ -3,7 +3,7 @@ namespace Consolidation\AnnotatedCommand\Parser;
 
 /**
  * An associative array that maps from key to default value;
- * each entry can also have a description.
+ * each entry can also have a description and suggested values.
  */
 class DefaultsWithDescriptions
 {
@@ -24,6 +24,11 @@ class DefaultsWithDescriptions
     protected $descriptions;
 
     /**
+     * @var array Associative array of key : suggestions mappings
+     */
+    protected $suggestedValues;
+
+    /**
      * @var mixed Default value that the default value of items in
      * the collection should take when not specified in the 'add' method.
      */
@@ -36,6 +41,7 @@ class DefaultsWithDescriptions
             return isset($value);
         });
         $this->descriptions = [];
+        $this->suggestedValues = [];
         $this->defaultDefault = $defaultDefault;
     }
 
@@ -115,13 +121,28 @@ class DefaultsWithDescriptions
     }
 
     /**
+     * Get the suggested values for an item.
+     *
+     * @param string $key The key of the item.
+     * @return array|\Closure
+     */
+    public function getSuggestedValues($key)
+    {
+        if (array_key_exists($key, $this->suggestedValues)) {
+            return $this->suggestedValues[$key];
+        }
+        return [];
+    }
+
+    /**
      * Add another argument to this command.
      *
      * @param string $key Name of the argument.
      * @param string $description Help text for the argument.
      * @param mixed $defaultValue The default value for the argument.
+     * @param array|\Closure $suggestions Possible values for the argument or option.
      */
-    public function add($key, $description = '', $defaultValue = null)
+    public function add($key, $description = '', $defaultValue = null, $suggestedValues = [])
     {
         if (!$this->exists($key) || isset($defaultValue)) {
             $this->values[$key] = isset($defaultValue) ? $defaultValue : $this->defaultDefault;
@@ -129,6 +150,10 @@ class DefaultsWithDescriptions
         unset($this->descriptions[$key]);
         if (!empty($description)) {
             $this->descriptions[$key] = $description;
+        }
+        unset($this->suggestedValues[$key]);
+        if (!empty($suggestedValues)) {
+            $this->suggestedValues[$key] = $suggestedValues;
         }
     }
 
@@ -165,6 +190,7 @@ class DefaultsWithDescriptions
     {
         unset($this->values[$key]);
         unset($this->descriptions[$key]);
+        unset($this->suggestedValues[$key]);
     }
 
     /**

--- a/tests/src/ExampleAttributesCommandFile.php
+++ b/tests/src/ExampleAttributesCommandFile.php
@@ -59,7 +59,7 @@ class ExampleAttributesCommandFile
 
     #[CLI\Command(name: 'test:arithmatic', aliases: ['arithmatic'])]
     #[CLI\Help(description: 'This is the test:arithmatic command', synopsis: "This command will add one and two. If the --negate flag\nis provided, then the result is negated.",)]
-    #[CLI\Argument(name: 'one', description: 'The first number to add.')]
+    #[CLI\Argument(name: 'one', description: 'The first number to add.', suggestedValues: [1,2,3,4,5])]
     #[CLI\Argument(name: 'two', description: 'The other number to add.')]
     #[CLI\Option(name: 'negate', description: 'Whether or not the result should be negated.')]
     #[CLI\Usage(name: '2 2 --negate', description: 'Add two plus two and then negate.')]
@@ -103,8 +103,8 @@ class ExampleAttributesCommandFile
      */
     public function testArithmaticComplete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
-        if ($input->mustSuggestArgumentValuesFor('one') || $input->mustSuggestArgumentValuesFor('two')) {
-            $suggestions->suggestValues(range(0, 9));
+        if ($input->mustSuggestArgumentValuesFor('two')) {
+            $suggestions->suggestValues(range(10, 15));
         }
     }
 }


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Support for the input definition feature of https://symfony.com/blog/new-in-symfony-6-1-improved-console-autocompletion#completion-values-in-input-definitions.

### Description
I've only implemented this for Attribute commands since it seems undesirable to complicate the `@argument` and `@option` annotations beyond name+description.

The intent is that all this code is backward compatible with Symfony 4/5.

An early Drush implementation that uses this code is at https://github.com/drush-ops/drush/pull/5097
