### PR TITLE
Only ignore commands in parent classes if flag is set

### DIFF
--- a/src/AnnotatedCommandFactory.php
+++ b/src/AnnotatedCommandFactory.php
@@ -28,6 +28,9 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
     /** var bool */
     protected static $ignoreCommandsInTraits = true;
 
+    /** var bool */
+    protected static $ignoreCommandsInParentClasses = false;
+
     /** var CommandProcessor */
     protected $commandProcessor;
 
@@ -63,6 +66,22 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
     public static function setIgnoreCommandsInTraits(bool $skipTraitFiles)
     {
         static::$ignoreCommandsInTraits = $skipTraitFiles;
+    }
+
+    /**
+     * Typically, commands should not be inherited from parent classes;
+     * however, some applications make use of this feature to package
+     * commands in libraries, so we must allow command files in traits
+     * to maintain backwards compatibility. Call this method to skip the
+     * parsing of trait files for a performance boost.
+     *
+     * In future versions, this property be removed, and commands will
+     * not be parsed from traits. Use Robo plugins as the preferred method
+     * of distributing shared commands.
+     */
+    public static function setIgnoreCommandsInParentClasses(bool $ignoreCommandsInParentClasses)
+    {
+        static::$ignoreCommandsInParentClasses = $ignoreCommandsInParentClasses;
     }
 
     public function __construct()
@@ -287,7 +306,7 @@ class AnnotatedCommandFactory implements AutomaticOptionsProviderInterface
             function ($m) use ($commandFileInstance, $commandClass) {
                 $reflectionMethod = new \ReflectionMethod($commandFileInstance, $m);
                 $name = $reflectionMethod->getFileName();
-                if ($reflectionMethod->getDeclaringClass()->getName() !== $commandClass) {
+                if (static::$ignoreCommandsInParentClasses && $reflectionMethod->getDeclaringClass()->getName() !== $commandClass) {
                     return false;
                 }
                 if ($reflectionMethod->isStatic() || preg_match('#^_#', $m)) {


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
This fixes the issue raised in https://github.com/consolidation/annotated-command/pull/273.
