### PR TITLE
Failing test: default value and therefore data type of parameter-defi…

### DIFF
--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -631,21 +631,26 @@ class CommandInfo
         $this->addOptionOrArgumentDescription($this->arguments(), $name, $description, $suggestions);
     }
 
-    public function addOptionDescription($name, $description, $suggestedValues = [])
+    public function addOptionDescription($name, $description)
     {
         $variableName = $this->findMatchingOption($name);
+        $defaultFromParameter = null;
         if ($this->simpleOptionParametersAllowed && $this->arguments()->exists($variableName)) {
-            $existingArg = $this->arguments()->removeMatching($variableName);
+            $defaultFromParameter = $this->arguments()->removeMatching($variableName);
             // One of our parameters is an option, not an argument. Flag it so that we can inject the right value when needed.
             $this->parameterMap[$variableName] = true;
         }
-        $this->addOptionOrArgumentDescription($this->options(), $variableName, $description, $suggestedValues);
+        $this->addOptionOrArgumentDescription($this->options(), $variableName, $description, [], $defaultFromParameter);
     }
 
-    protected function addOptionOrArgumentDescription(DefaultsWithDescriptions $set, $variableName, $description, $suggestedValues = [])
+    // Note: 'suggestions' passed in, but not used
+    protected function addOptionOrArgumentDescription(DefaultsWithDescriptions $set, $variableName, $description, $suggestions = [], $defaultFromParameter = null)
     {
         list($description, $defaultValue) = $this->splitOutDefault($description);
-        $set->add($variableName, $description, null, $suggestedValues);
+        if (empty($defaultValue) && !empty($defaultFromParameter)) {
+            $defaultValue = $defaultFromParameter;
+        }
+        $set->add($variableName, $description);
         if ($defaultValue !== null) {
             $set->setDefaultValue($variableName, $defaultValue);
         }

--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -386,6 +386,29 @@ EOT;
         $this->assertRunCommandViaApplicationEquals($command, $input, 'alphabet');
     }
 
+    function testImprovedOptionsCommand()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'improvedOptions');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
+        $this->assertEquals('improved:options', $command->getName());
+        $this->assertEquals('This is the improved way to declare options.', $command->getDescription());
+        $this->assertEquals("This command will echo its arguments and options", $command->getHelp());
+        $this->assertEquals('c', implode(',', $command->getAliases()));
+        $this->assertEquals('improved:options [--o1] [--o2] [--] <a1> <a2>', $command->getSynopsis());
+        $this->assertEquals('improved:options a b --o1=x --o2=y', implode(',', $command->getUsages()));
+
+        $input = new StringInput('improved:options a b');
+        $this->assertRunCommandViaApplicationEquals($command, $input, "args are a and b, and options are 'one' and 'two'");
+
+        $input = new StringInput('improved:options a b --o1=x --o2=y');
+        $this->assertRunCommandViaApplicationEquals($command, $input, "args are a and b, and options are 'x' and 'y'");
+    }
+
     function testCatCommand()
     {
         $path = __DIR__ . '/fixtures/stdin.txt';

--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -399,7 +399,7 @@ EOT;
         $this->assertEquals('This is the improved way to declare options.', $command->getDescription());
         $this->assertEquals("This command will echo its arguments and options", $command->getHelp());
         $this->assertEquals('c', implode(',', $command->getAliases()));
-        $this->assertEquals('improved:options [--o1] [--o2] [--] <a1> <a2>', $command->getSynopsis());
+        $this->assertEquals('improved:options [--o1 [O1]] [--o2 [O2]] [--] <a1> <a2>', $command->getSynopsis());
         $this->assertEquals('improved:options a b --o1=x --o2=y', implode(',', $command->getUsages()));
 
         $input = new StringInput('improved:options a b');

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -60,6 +60,9 @@ class AttributesCommandFactoryTest extends TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'this that and the other thing');
     }
 
+    /**
+     * @requires PHP >= 8.0
+     */
     function testImprovedOptionsCommand()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -60,6 +60,29 @@ class AttributesCommandFactoryTest extends TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'this that and the other thing');
     }
 
+    function testImprovedOptionsCommand()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'improvedOptions');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
+        $this->assertEquals('improved:options', $command->getName());
+        $this->assertEquals('This is the improved way to declare options.', $command->getDescription());
+        $this->assertEquals("This command will echo its arguments and options", $command->getHelp());
+        $this->assertEquals('c', implode(',', $command->getAliases()));
+        $this->assertEquals('improved:options [--o1] [--o2] [--] <a1> <a2>', $command->getSynopsis());
+        $this->assertEquals('improved:options a b --o1=x --o2=y', implode(',', $command->getUsages()));
+
+        $input = new StringInput('improved:options a b');
+        $this->assertRunCommandViaApplicationEquals($command, $input, "args are a and b, and options are 'one' and 'two'");
+
+        $input = new StringInput('improved:options a b --o1=x --o2=y');
+        $this->assertRunCommandViaApplicationEquals($command, $input, "args are a and b, and options are 'x' and 'y'");
+    }
+
     /**
      * @requires PHP >= 8.0
      */

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -73,7 +73,7 @@ class AttributesCommandFactoryTest extends TestCase
         $this->assertEquals('This is the improved way to declare options.', $command->getDescription());
         $this->assertEquals("This command will echo its arguments and options", $command->getHelp());
         $this->assertEquals('c', implode(',', $command->getAliases()));
-        $this->assertEquals('improved:options [--o1] [--o2] [--] <a1> <a2>', $command->getSynopsis());
+        $this->assertEquals('improved:options [--o1 [O1]] [--o2 [O2]] [--] <a1> <a2>', $command->getSynopsis());
         $this->assertEquals('improved:options a b --o1=x --o2=y', implode(',', $command->getUsages()));
 
         $input = new StringInput('improved:options a b');

--- a/tests/src/ExampleAttributesCommandFile.php
+++ b/tests/src/ExampleAttributesCommandFile.php
@@ -57,6 +57,19 @@ class ExampleAttributesCommandFile
         return implode(' ', $args);
     }
 
+    #[CLI\Command(name: 'improved:options', aliases: ['c'])]
+    #[CLI\Help(description: 'This is the improved way to declare options.', synopsis: "This command will echo its arguments and options")]
+
+    #[CLI\Argument(name: 'a1', description: 'an arg')]
+    #[CLI\Argument(name: 'a2', description: 'another arg')]
+    #[CLI\Option(name: 'o1', description: 'an option')]
+    #[CLI\Option(name: 'o2', description: 'another option')]
+    #[CLI\Usage(name: 'a b --o1=x --o2=y', description: 'Print some example values')]
+    public function improvedOptions($a1, $a2, $o1 = 'one', $o2 = 'two')
+    {
+        return "args are $a1 and $a2, and options are " . var_export($o1, true) . ' and ' . var_export($o2, true);
+    }
+
     #[CLI\Command(name: 'test:arithmatic', aliases: ['arithmatic'])]
     #[CLI\Help(description: 'This is the test:arithmatic command', synopsis: "This command will add one and two. If the --negate flag\nis provided, then the result is negated.",)]
     #[CLI\Argument(name: 'one', description: 'The first number to add.', suggestedValues: [1,2,3,4,5])]

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -154,6 +154,25 @@ class ExampleCommandFile
     }
 
     /**
+     * This is the improved way to declare options.
+     *
+     * This command will echo its arguments and options
+     *
+     * @command improved:options
+     * @param string $a1 an arg
+     * @param string $a2 another arg
+     * @option $o1 an option
+     * @option $o2 another option
+     * @aliases c
+     * @usage a b --o1=x --o2=y
+     *   Print some example values
+     */
+    public function improvedOptions($a1, $a2, $o1 = 'one', $o2 = 'two')
+    {
+        return "args are $a1 and $a2, and options are " . var_export($o1, true) . ' and ' . var_export($o2, true);
+    }
+
+    /**
      * @command my:repeat
      */
     public function myRepeat($one, $two = '', array $options = ['repeat' => 1])


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
When defining cli options as ordinary method parameters, the default value is getting dropped. This means that the type and default value of the option ends up being wrong.

### Description
Starting with a failing test.