### PR TITLE
Allow command help and descriptions to be defined via docblock commen…

### DIFF
--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -385,6 +385,14 @@ class CommandInfo
     }
 
     /**
+     * Determine if help was provided for this command info
+     */
+    public function hasHelp()
+    {
+        return !empty($this->help) || !empty($this->description);
+    }
+
+    /**
      * Get the help text of the command (the description)
      */
     public function getHelp()

--- a/src/Parser/Internal/AttributesDocBlockParser.php
+++ b/src/Parser/Internal/AttributesDocBlockParser.php
@@ -33,5 +33,32 @@ class AttributesDocBlockParser
                 call_user_func([$attribute->getName(), 'handle'], $attribute, $this->commandInfo);
             }
         }
+
+        // If 'CLI\Help' is not defined, then get the help from the docblock comment
+        if (!$this->commandInfo->hasHelp()) {
+            $doc = $this->reflection->getDocComment();
+            $doc = BespokeDocBlockParser::stripLeadingCommentCharacters($doc);
+
+            $lines = explode("\n", $doc);
+
+            // Everything up to the first blank line goes in the description.
+            $description = array_shift($lines);
+            while (BespokeDocBlockParser::nextLineIsNotEmpty($lines)) {
+                $description .= ' ' . array_shift($lines);
+            }
+
+            // Everything else goes in the help, up to the first @annotation
+            // (e.g. @param)
+            $help = '';
+            foreach ($lines as $line) {
+                if (preg_match('#^[ \t]*@#', $line)) {
+                    break;
+                }
+                $help .= $line . PHP_EOL;
+            }
+
+            $this->commandInfo->setDescription($description);
+            $this->commandInfo->setHelp(trim($help));
+        }
     }
 }

--- a/src/Parser/Internal/AttributesDocBlockParser.php
+++ b/src/Parser/Internal/AttributesDocBlockParser.php
@@ -37,13 +37,13 @@ class AttributesDocBlockParser
         // If 'CLI\Help' is not defined, then get the help from the docblock comment
         if (!$this->commandInfo->hasHelp()) {
             $doc = $this->reflection->getDocComment();
-            $doc = BespokeDocBlockParser::stripLeadingCommentCharacters($doc);
+            $doc = DocBlockUtils::stripLeadingCommentCharacters($doc);
 
             $lines = explode("\n", $doc);
 
             // Everything up to the first blank line goes in the description.
             $description = array_shift($lines);
-            while (BespokeDocBlockParser::nextLineIsNotEmpty($lines)) {
+            while (DocBlockUtils::nextLineIsNotEmpty($lines)) {
                 $description .= ' ' . array_shift($lines);
             }
 

--- a/src/Parser/Internal/BespokeDocBlockParser.php
+++ b/src/Parser/Internal/BespokeDocBlockParser.php
@@ -223,11 +223,20 @@ class BespokeDocBlockParser
         return $this->fqcnCache->qualify($this->reflection->getFileName(), $className);
     }
 
-    private function parseDocBlock($doc)
+    public static function stripLeadingCommentCharacters($doc)
     {
         // Remove the leading /** and the trailing */
         $doc = preg_replace('#^\s*/\*+\s*#', '', $doc);
         $doc = preg_replace('#\s*\*+/\s*#', '', $doc);
+        $doc = preg_replace('#^[ \t]*\** ?#m', '', $doc);
+
+        return $doc;
+    }
+
+    private function parseDocBlock($doc)
+    {
+        // Remove the leading /** and the trailing */
+        $doc = static::stripLeadingCommentCharacters($doc);
 
         // Nothing left? Exit.
         if (empty($doc)) {
@@ -240,7 +249,6 @@ class BespokeDocBlockParser
         foreach (explode("\n", $doc) as $row) {
             // Remove trailing whitespace and leading space + '*'s
             $row = rtrim($row);
-            $row = preg_replace('#^[ \t]*\**#', '', $row);
 
             if (!$tagFactory->parseLine($row)) {
                 $lines[] = $row;
@@ -264,7 +272,7 @@ class BespokeDocBlockParser
 
         // Everything up to the first blank line goes in the description.
         $description = array_shift($lines);
-        while ($this->nextLineIsNotEmpty($lines)) {
+        while (static::nextLineIsNotEmpty($lines)) {
             $description .= ' ' . array_shift($lines);
         }
 
@@ -275,7 +283,7 @@ class BespokeDocBlockParser
         $this->commandInfo->setHelp($help);
     }
 
-    protected function nextLineIsNotEmpty($lines)
+    public static function nextLineIsNotEmpty($lines)
     {
         if (empty($lines)) {
             return false;

--- a/src/Parser/Internal/BespokeDocBlockParser.php
+++ b/src/Parser/Internal/BespokeDocBlockParser.php
@@ -223,20 +223,11 @@ class BespokeDocBlockParser
         return $this->fqcnCache->qualify($this->reflection->getFileName(), $className);
     }
 
-    public static function stripLeadingCommentCharacters($doc)
-    {
-        // Remove the leading /** and the trailing */
-        $doc = preg_replace('#^\s*/\*+\s*#', '', $doc);
-        $doc = preg_replace('#\s*\*+/\s*#', '', $doc);
-        $doc = preg_replace('#^[ \t]*\** ?#m', '', $doc);
-
-        return $doc;
-    }
 
     private function parseDocBlock($doc)
     {
         // Remove the leading /** and the trailing */
-        $doc = static::stripLeadingCommentCharacters($doc);
+        $doc = DocBlockUtils::stripLeadingCommentCharacters($doc);
 
         // Nothing left? Exit.
         if (empty($doc)) {
@@ -283,14 +274,9 @@ class BespokeDocBlockParser
         $this->commandInfo->setHelp($help);
     }
 
-    public static function nextLineIsNotEmpty($lines)
+    protected function nextLineIsNotEmpty($lines)
     {
-        if (empty($lines)) {
-            return false;
-        }
-
-        $nextLine = trim($lines[0]);
-        return !empty($nextLine);
+        return DocBlockUtils::nextLineIsNotEmpty($lines);
     }
 
     protected function processAllTags($tags)

--- a/src/Parser/Internal/DocBlockUtils.php
+++ b/src/Parser/Internal/DocBlockUtils.php
@@ -1,0 +1,28 @@
+<?php
+namespace Consolidation\AnnotatedCommand\Parser\Internal;
+
+/**
+ * Simple utility methods when working with docblock comments.
+ */
+class DocBlockUtils
+{
+    public static function stripLeadingCommentCharacters($doc)
+    {
+        // Remove the leading /** and the trailing */
+        $doc = preg_replace('#^\s*/\*+\s*#', '', $doc);
+        $doc = preg_replace('#\s*\*+/\s*#', '', $doc);
+        $doc = preg_replace('#^[ \t]*\** ?#m', '', $doc);
+
+        return $doc;
+    }
+
+    public static function nextLineIsNotEmpty($lines)
+    {
+        if (empty($lines)) {
+            return false;
+        }
+
+        $nextLine = trim($lines[0]);
+        return !empty($nextLine);
+    }
+}

--- a/tests/src/ExampleAttributesCommandFile.php
+++ b/tests/src/ExampleAttributesCommandFile.php
@@ -30,8 +30,13 @@ class ExampleAttributesCommandFile
         $this->output = $output;
     }
 
+    /**
+     * This is the my:echo command
+     *
+     * This command will concatenate two parameters. If the --flip flag
+     * is provided, then the result is the concatenation of two and one.
+     */
     #[CLI\Command(name: 'my:echo', aliases: ['c'])]
-    #[CLI\Help(description: 'This is the my:echo command', synopsis: "This command will concatenate two parameters. If the --flip flag\nis provided, then the result is the concatenation of two and one.",)]
     #[CLI\Argument(name: 'one', description: 'The first parameter')]
     #[CLI\Argument(name: 'two', description: 'The other parameter')]
     #[CLI\Option(name: 'flip', description: 'Whether or not the second parameter should come first in the result.')]
@@ -44,8 +49,13 @@ class ExampleAttributesCommandFile
         return "{$one}{$two}";
     }
 
+    /**
+     * This is the improved:echo command
+     *
+     * This command will concatenate two parameters. If the --flip flag
+     * is provided, then the result is the concatenation of two and one.
+     */
     #[CLI\Command(name: 'improved:echo', aliases: ['c'])]
-    #[CLI\Help(description: 'This is the improved:echo command', synopsis: "This command will concatenate two parameters. If the --flip flag\nis provided, then the result is the concatenation of two and one.",)]
     #[CLI\Argument(name: 'args', description: 'Any number of arguments separated by spaces.')]
     #[CLI\Option(name: 'flip', description: 'Whether or not the second parameter should come first in the result.')]
     #[CLI\Usage(name: 'bet alpha --flip', description: 'Concatenate "alpha" and "bet".')]
@@ -57,9 +67,12 @@ class ExampleAttributesCommandFile
         return implode(' ', $args);
     }
 
+    /**
+     * This is the improved way to declare options.
+     *
+     * This command will echo its arguments and options
+     */
     #[CLI\Command(name: 'improved:options', aliases: ['c'])]
-    #[CLI\Help(description: 'This is the improved way to declare options.', synopsis: "This command will echo its arguments and options")]
-
     #[CLI\Argument(name: 'a1', description: 'an arg')]
     #[CLI\Argument(name: 'a2', description: 'another arg')]
     #[CLI\Option(name: 'o1', description: 'an option')]
@@ -70,8 +83,19 @@ class ExampleAttributesCommandFile
         return "args are $a1 and $a2, and options are " . var_export($o1, true) . ' and ' . var_export($o2, true);
     }
 
+    /**
+     * This is the test:arithmatic command
+     *
+     * This command will add one and two. If the --negate flag
+     * is provided, then the result is negated.
+     *
+     * @param string $one The first parameter
+     * @param string $two The second parameter
+     * @param array $options The list of options
+     *
+     * Any text after the attributes is omitted from the help description.
+     */
     #[CLI\Command(name: 'test:arithmatic', aliases: ['arithmatic'])]
-    #[CLI\Help(description: 'This is the test:arithmatic command', synopsis: "This command will add one and two. If the --negate flag\nis provided, then the result is negated.",)]
     #[CLI\Argument(name: 'one', description: 'The first number to add.', suggestedValues: [1,2,3,4,5])]
     #[CLI\Argument(name: 'two', description: 'The other number to add.')]
     #[CLI\Option(name: 'negate', description: 'Whether or not the result should be negated.')]


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Allows help text to be placed in the docblock command at the top of an Attribute Command method.

### Description
When using attribute commands, `#[CLI\Argument(name: 'one')]` is at least as good as ` * @param string $one` for describing arguments, options, and so on; however, the help text is much less readable when encapsulated inside a `#[CLI\Help(...)]` attribute, compared to the same help text written in a docblock comment.

This PR allows help text to be placed in the docblock comment as before, even when using attributes to define the command name, arguments, options and so on. The first line is the short command description, whereas the docblock content after the first blank line is the long-form help text. Docblock annotations may still be used for the purpose of documenting the PHP method parameters; attributes and annotations may not otherwise be mixed. Any text that appears below any annotation is excluded from the help text.

Note that `#[CLI\Help(...)]` attributes are still supported; if used, the docblock comment is ignored.

See the example attribute command test fixture for examples.
