### PR TITLE
Add ac script

### DIFF
--- a/ac
+++ b/ac
@@ -1,0 +1,9 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * A script for ad hoc testing of commands defined in this project.
+ *
+ * You may also test our autocomplete. Get info by running `ac completion --help`
+ */
+require __DIR__ . '/ac.php';


### PR DESCRIPTION

Add an `ac` script as thats more natural for testing autocomplete. Also document the command which helps you install autocompletion. Remember that Symfony 6.2 is needed to get ZSH, Fish, and Bash support.