### PR TITLE
PHP 8.2 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,12 @@ jobs:
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
 
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            codecov: true
+            php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/Parser/Internal/BespokeDocBlockParser.php
+++ b/src/Parser/Internal/BespokeDocBlockParser.php
@@ -12,6 +12,9 @@ use Consolidation\AnnotatedCommand\Parser\DefaultsWithDescriptions;
 class BespokeDocBlockParser
 {
     protected $fqcnCache;
+    protected $commandInfo;
+    protected $reflection;
+    protected $optionParamName;
 
     /**
      * @var array


### PR DESCRIPTION
### Overview
This pull request adds testing on PHP 8.2 and enables it in the tests.

### Summary
Fixes this issue: https://php.watch/versions/8.2/dynamic-properties-deprecated
