### PR TITLE
Allow for just one param to be passed in Help and Topics Attributes

### DIFF
--- a/src/Attributes/Help.php
+++ b/src/Attributes/Help.php
@@ -13,21 +13,25 @@ class Help
      *   A one line description.
      * @param $synopsis
      *   A multi-line help text.
-     * @param bool|null $hidden
+     * @param bool $hidden
      *   Hide the command from the help list.
      */
     public function __construct(
-        public string $description,
-        public ?string $synopsis,
+        public ?string $description = null,
+        public ?string $synopsis = null,
         public bool $hidden = false
     ) {
     }
 
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $args = $attribute->getArguments();
-        $commandInfo->setDescription($args['description']);
-        $commandInfo->setHelp($args['synopsis'] ?? '');
-        $commandInfo->setHidden($args['hidden'] ?? false);
+        $instance = $attribute->newInstance();
+        if ($instance->description) {
+            $commandInfo->setDescription($instance->description);
+        }
+        if ($instance->synopsis) {
+            $commandInfo->setHelp($instance->synopsis);
+        }
+        $commandInfo->setHidden($instance->hidden);
     }
 }

--- a/src/Attributes/Topics.php
+++ b/src/Attributes/Topics.php
@@ -11,19 +11,21 @@ class Topics
     /**
      * @param string[] $topics
      *   An array of topics that are related to this command.
-     * @param $isTopic
-     *   This command should appear on the list of topics.
+     * @param $path
+     *   The path to a markdown file, when this command is itself a topic.
      */
     public function __construct(
-        public ?array $topics,
-        public bool $isTopic = false,
+        public ?array $topics = [],
+        public ?string $path = null,
     ) {
     }
 
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $args = $attribute->getArguments();
-        $commandInfo->addAnnotation('topics', $args['topics'] ?? []);
-        $commandInfo->addAnnotation('topic', $args['is_topic'] ?? false);
+        $instance = $attribute->newInstance();
+        $commandInfo->addAnnotation('topics', $instance->topics);
+        if ($instance->path) {
+            $commandInfo->addAnnotation('topic', $instance->path);
+        }
     }
 }


### PR DESCRIPTION
Drush is not using Attributes for synopsis and description parts in Help

### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
