### PR TITLE
Topic attribute

### DIFF
--- a/src/Attributes/Topic.php
+++ b/src/Attributes/Topic.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Consolidation\AnnotatedCommand\Attributes;
+
+use Attribute;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Topic
+{
+    public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
+    {
+        $commandInfo->addAnnotation('topic', true);
+    }
+
+}

--- a/src/Attributes/Topic.php
+++ b/src/Attributes/Topic.php
@@ -12,5 +12,4 @@ class Topic
     {
         $commandInfo->addAnnotation('topic', true);
     }
-
 }


### PR DESCRIPTION
Used when a command *is* a topic. Analogous to `@topic` annotation

### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
