### PR TITLE
Add new public ->addOptionDescriptionDefaultValue() method

### DIFF
--- a/src/Attributes/HookSelector.php
+++ b/src/Attributes/HookSelector.php
@@ -16,7 +16,7 @@ class HookSelector
      */
     public function __construct(
         public string $name,
-        public ?string $value = null,
+        public mixed $value = true,
     ) {
     }
 

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -639,11 +639,14 @@ class CommandInfo
         $this->addOptionOrArgumentDescription($this->arguments(), $name, $description, $suggestedValues);
     }
 
-    public function addOptionDescriptionDefaultValue($name, $description, $suggestedValues = [], $defaultValue = null) {
+    public function addOption($name, $description, $suggestedValues = [], $defaultValue = null) {
         $this->addOptionOrArgumentDescription($this->options(), $name, $description, $suggestedValues, $defaultValue);
     }
 
-    public function addOptionDescription($name, $description, $suggestedValues = [])
+    /**
+     * @deprecated Use addOption() instead.
+     */
+    public function addOptionDescription($name, $description, $suggestedValues = [], $defaultValue = null)
     {
         $variableName = $this->findMatchingOption($name);
         $defaultFromParameter = null;
@@ -652,7 +655,7 @@ class CommandInfo
             // One of our parameters is an option, not an argument. Flag it so that we can inject the right value when needed.
             $this->parameterMap[$variableName] = true;
         }
-        $this->addOptionOrArgumentDescription($this->options(), $variableName, $description, $suggestedValues, $defaultFromParameter);
+        $this->addOptionOrArgumentDescription($this->options(), $variableName, $description, $suggestedValues, $defaultValue ?? $defaultFromParameter);
     }
 
     protected function addOptionOrArgumentDescription(DefaultsWithDescriptions $set, $variableName, $description, $suggestedValues = [], $defaultFromParameter = null)

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -639,6 +639,10 @@ class CommandInfo
         $this->addOptionOrArgumentDescription($this->arguments(), $name, $description, $suggestedValues);
     }
 
+    public function addOptionDescriptionDefaultValue($name, $description, $suggestedValues = [], $defaultValue = null) {
+        $this->addOptionOrArgumentDescription($this->options(), $name, $description, $suggestedValues, $defaultValue);
+    }
+
     public function addOptionDescription($name, $description, $suggestedValues = [])
     {
         $variableName = $this->findMatchingOption($name);

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -639,7 +639,8 @@ class CommandInfo
         $this->addOptionOrArgumentDescription($this->arguments(), $name, $description, $suggestedValues);
     }
 
-    public function addOption($name, $description, $suggestedValues = [], $defaultValue = null) {
+    public function addOption($name, $description, $suggestedValues = [], $defaultValue = null)
+    {
         $this->addOptionOrArgumentDescription($this->options(), $name, $description, $suggestedValues, $defaultValue);
     }
 


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [X] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
- Adds method. See https://github.com/drush-ops/drush/pull/5443
- An unrelated fix to HookSelector so its annotations return true for $annotationData->hasAnnotation().

