### PR TITLE
Fix bug with simple options with dashes in their names.

### DIFF
--- a/src/CommandData.php
+++ b/src/CommandData.php
@@ -203,9 +203,9 @@ class CommandData
         // into the correct spot in the parameters list.
         if (!empty($this->parameterMap)) {
             $mappedArgs = [];
-            foreach ($this->parameterMap as $name => $isOption) {
-                if ($isOption) {
-                    $mappedArgs[$name] = $this->input->getOption($name);
+            foreach ($this->parameterMap as $name => $mappedName) {
+                if ($mappedName) {
+                    $mappedArgs[$name] = $this->input->getOption($mappedName);
                 } else {
                     $mappedArgs[$name] = array_shift($args);
                 }

--- a/src/Parser/DefaultsWithDescriptions.php
+++ b/src/Parser/DefaultsWithDescriptions.php
@@ -98,12 +98,29 @@ class DefaultsWithDescriptions
      */
     public function removeMatching($key)
     {
-        if (!array_key_exists($key, $this->values)) {
+        $key = $this->approximatelyMatchingKey($key);
+        if (!$key) {
             return '';
         }
         $result = $this->values[$key];
         unset($this->values[$key]);
         return $result;
+    }
+
+    public function approximatelyMatchingKey($key)
+    {
+        $key = $this->simplifyKey($key);
+        foreach ($this->values as $k => $v) {
+            if ($key === $this->simplifyKey($k)) {
+                return $k;
+            }
+        }
+        return '';
+    }
+
+    protected function simplifyKey($key)
+    {
+        return strtolower(preg_replace('#[-_]#', '', $key));
     }
 
     /**

--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -386,6 +386,46 @@ EOT;
         $this->assertRunCommandViaApplicationEquals($command, $input, 'alphabet');
     }
 
+    function testSnakeEchoCommand()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'snakeCaseEcho');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
+        $this->assertEquals('snake:echo', $command->getName());
+        $this->assertEquals('This is the snake_case version of the my:echo command', $command->getDescription());
+        $this->assertEquals("This command will concatenate two parameters. If the --flip-flag\nis provided, then the result is the concatenation of two and one.", $command->getHelp());
+        $this->assertEquals('c', implode(',', $command->getAliases()));
+        $this->assertEquals('snake:echo [--flip-flag] [--] [<args>...]', $command->getSynopsis());
+        $this->assertEquals('snake:echo bet alpha --flip-flag', implode(',', $command->getUsages()));
+
+        $input = new StringInput('snake:echo bet alpha --flip-flag');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'alphabet');
+    }
+
+    function testCamelEchoCommand()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'camelCaseEcho');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
+        $this->assertEquals('camel:echo', $command->getName());
+        $this->assertEquals('This is the camelCase version of the my:echo command', $command->getDescription());
+        $this->assertEquals("This command will concatenate two parameters. If the --flip-flag\nis provided, then the result is the concatenation of two and one.", $command->getHelp());
+        $this->assertEquals('c', implode(',', $command->getAliases()));
+        $this->assertEquals('camel:echo [--flip-flag] [--] [<args>...]', $command->getSynopsis());
+        $this->assertEquals('camel:echo bet alpha --flip-flag', implode(',', $command->getUsages()));
+
+        $input = new StringInput('camel:echo bet alpha --flip-flag');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'alphabet');
+    }
+
     function testImprovedOptionsCommand()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleCommandFile;

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -61,6 +61,9 @@ class AttributesCommandFactoryTest extends TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'this that and the other thing');
     }
 
+    /**
+     * @requires PHP >= 8.0
+     */
     function testSnakeEchoCommand()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;
@@ -81,6 +84,9 @@ class AttributesCommandFactoryTest extends TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'alphabet');
     }
 
+    /**
+     * @requires PHP >= 8.0
+     */
     function testCamelEchoCommand()
     {
         $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -61,6 +61,46 @@ class AttributesCommandFactoryTest extends TestCase
         $this->assertRunCommandViaApplicationEquals($command, $input, 'this that and the other thing');
     }
 
+    function testSnakeEchoCommand()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'snakeCaseEcho');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
+        $this->assertEquals('snake:echo', $command->getName());
+        $this->assertEquals('This is the snake_case version of the my:echo command', $command->getDescription());
+        $this->assertEquals("This command will concatenate two parameters. If the --flip-flag\nis provided, then the result is the concatenation of two and one.", $command->getHelp());
+        $this->assertEquals('c', implode(',', $command->getAliases()));
+        $this->assertEquals('snake:echo [--flip-flag] [--] [<args>...]', $command->getSynopsis());
+        $this->assertEquals('snake:echo bet alpha --flip-flag', implode(',', $command->getUsages()));
+
+        $input = new StringInput('snake:echo bet alpha --flip-flag');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'alphabet');
+    }
+
+    function testCamelEchoCommand()
+    {
+        $this->commandFileInstance = new \Consolidation\TestUtils\ExampleAttributesCommandFile;
+        $this->commandFactory = new AnnotatedCommandFactory();
+        $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'camelCaseEcho');
+
+        $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);
+
+        $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
+        $this->assertEquals('camel:echo', $command->getName());
+        $this->assertEquals('This is the camelCase version of the my:echo command', $command->getDescription());
+        $this->assertEquals("This command will concatenate two parameters. If the --flip-flag\nis provided, then the result is the concatenation of two and one.", $command->getHelp());
+        $this->assertEquals('c', implode(',', $command->getAliases()));
+        $this->assertEquals('camel:echo [--flip-flag] [--] [<args>...]', $command->getSynopsis());
+        $this->assertEquals('camel:echo bet alpha --flip-flag', implode(',', $command->getUsages()));
+
+        $input = new StringInput('camel:echo bet alpha --flip-flag');
+        $this->assertRunCommandViaApplicationEquals($command, $input, 'alphabet');
+    }
+
     /**
      * @requires PHP >= 8.0
      */

--- a/tests/FullStackTest.php
+++ b/tests/FullStackTest.php
@@ -140,6 +140,8 @@ class FullStackTest extends TestCase
         $this->assertRunCommandViaApplicationEquals('simulated:status', '42');
         $this->assertRunCommandViaApplicationEquals('example:output', 'Hello, World.');
         $this->assertRunCommandViaApplicationEquals('example:cat bet alpha --flip', 'alphabet');
+        $this->assertRunCommandViaApplicationEquals('example:snake bet alpha --flip-flag', 'alphabet');
+        $this->assertRunCommandViaApplicationEquals('example:camel bet alpha --flip-flag', 'alphabet');
         $this->assertRunCommandViaApplicationEquals('example:echo a b c', "a\tb\tc");
         $this->assertRunCommandViaApplicationEquals('example:message', 'Shipwrecked; send bananas.');
         $this->assertRunCommandViaApplicationEquals('command:with-one-optional-argument', 'Hello, world');

--- a/tests/src/ExampleAttributesCommandFile.php
+++ b/tests/src/ExampleAttributesCommandFile.php
@@ -69,6 +69,42 @@ class ExampleAttributesCommandFile
     }
 
     /**
+     * This is the snake_case version of the my:echo command
+     *
+     * This command will concatenate two parameters. If the --flip-flag
+     * is provided, then the result is the concatenation of two and one.
+     */
+    #[CLI\Command(name: 'snake:echo', aliases: ['c'])]
+    #[CLI\Argument(name: 'args', description: 'Any number of arguments separated by spaces.')]
+    #[CLI\Option(name: 'flip-flag', description: 'Whether or not the second parameter should come first in the result.')]
+    #[CLI\Usage(name: 'bet alpha --flip-flag', description: 'Concatenate "alpha" and "bet".')]
+    public function snakeCaseEcho(array $args, $flip_flag = false)
+    {
+        if ($flip_flag) {
+            $args = array_reverse($args);
+        }
+        return implode('', $args);
+    }
+
+    /**
+     * This is the camelCase version of the my:echo command
+     *
+     * This command will concatenate two parameters. If the --flip-flag
+     * is provided, then the result is the concatenation of two and one.
+     */
+    #[CLI\Command(name: 'camel:echo', aliases: ['c'])]
+    #[CLI\Argument(name: 'args', description: 'Any number of arguments separated by spaces.')]
+    #[CLI\Option(name: 'flip-flag', description: 'Whether or not the second parameter should come first in the result.')]
+    #[CLI\Usage(name: 'bet alpha --flip-flag', description: 'Concatenate "alpha" and "bet".')]
+    public function camelCaseEcho(array $args, $flipFlag = false)
+    {
+        if ($flipFlag) {
+            $args = array_reverse($args);
+        }
+        return implode('', $args);
+    }
+
+    /**
      * This is the improved way to declare options.
      *
      * This command will echo its arguments and options

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -154,6 +154,48 @@ class ExampleCommandFile
     }
 
     /**
+     * This is the snake_case version of the my:echo command
+     *
+     * This command will concatenate two parameters. If the --flip-flag
+     * is provided, then the result is the concatenation of two and one.
+     *
+     * @command snake:echo
+     * @param array $args Variable arguments.
+     * @option flip-flag Whether or not the second parameter should come first in the result.
+     * @aliases c
+     * @usage bet alpha --flip-flag
+     *   Concatenate "alpha" and "bet".
+     */
+    public function snakeCaseEcho(array $args, $flip_flag = false)
+    {
+        if ($flip_flag) {
+            $args = array_reverse($args);
+        }
+        return implode('', $args);
+    }
+
+    /**
+     * This is the camelCase version of the my:echo command
+     *
+     * This command will concatenate two parameters. If the --flip-flag
+     * is provided, then the result is the concatenation of two and one.
+     *
+     * @command camel:echo
+     * @param array $args Variable arguments.
+     * @option flip-flag Whether or not the second parameter should come first in the result.
+     * @aliases c
+     * @usage bet alpha --flip-flag
+     *   Concatenate "alpha" and "bet".
+     */
+    public function camelCaseEcho(array $args, $flipFlag = false)
+    {
+        if ($flipFlag) {
+            $args = array_reverse($args);
+        }
+        return implode('', $args);
+    }
+
+    /**
      * This is the improved way to declare options.
      *
      * This command will echo its arguments and options

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -66,6 +66,32 @@ class AlphaCommandFile implements CustomEventAwareInterface
     }
 
     /**
+     * @command example:snake
+     *
+     * @option flip-flag A flag
+     */
+    public function exampleSnake($one, $two = '', $flip_flag = false)
+    {
+        if ($flip_flag) {
+            return "{$two}{$one}";
+        }
+        return "{$one}{$two}";
+    }
+
+    /**
+     * @command example:camel
+     *
+     * @option flip-flag A flag
+     */
+    public function exampleCamel($one, $two = '', $flipFlag = false)
+    {
+        if ($flipFlag) {
+            return "{$two}{$one}";
+        }
+        return "{$one}{$two}";
+    }
+
+    /**
      * @command example:echo
      */
     public function exampleEcho(array $args)


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
Is it a bug, or is it a feature? It is an oversight. The $options array allows for options that contain dashes in their name, but if you define an option with an $argumentName, there is no way to represent a dash.

### Description
This PR allows an `@option` annotation or option attribute to define an `option-name` with a dash that will then map to a variable named either `$optionName` or `$optionName`.