### PR TITLE
Only call setHidden() if value is true.

### DIFF
--- a/src/Attributes/Help.php
+++ b/src/Attributes/Help.php
@@ -32,6 +32,8 @@ class Help
         if ($instance->synopsis) {
             $commandInfo->setHelp($instance->synopsis);
         }
-        $commandInfo->setHidden($instance->hidden);
+        if ($instance->hidden) {
+            $commandInfo->setHidden($instance->hidden);
+        }
     }
 }


### PR DESCRIPTION
The problem is that hasAnnotation() is true even if the value of $hidden is false.

### Disposition
This pull request:

- [ x Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Fixes https://github.com/drush-ops/drush/issues/5505
