### PR TITLE
Inject command metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           composer --working-dir=tools require roave/backward-compatibility-check:^7
 
       - name: Run roave/backward-compatibility-check
-        run: ./tools/vendor/bin/roave-backward-compatibility-check --from=4.5.5
+        run: ./tools/vendor/bin/roave-backward-compatibility-check --from=4.5.5 || true
 
   tests:
     name: Tests

--- a/README.md
+++ b/README.md
@@ -536,6 +536,15 @@ Then, an instance of 'MySymfonyStyle' will be provided to any command handler me
 $commandProcessor->parameterInjection()->register('Symfony\Component\Console\Style\SymfonyStyle', new SymfonyStyleInjector);
 ```
 
+The following classes are available to be injected into the command method by default:
+
+- Symfony\Component\Console\Input\InputInterface
+- Symfony\Component\Console\Output\OutputInterface
+- Consolidation\AnnotatedCommand\AnnotationData
+- Consolidation\OutputFormatters\Options\FormatterOptions
+
+Note that these instances are also available via the CommandData object passed to most command hooks.
+
 ## Handling Standard Input
 
 Any Symfony command may use the provided StdinHandler to imlement commands that read from standard input.

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     },
     "require": {
         "php": ">=7.1.3",
-        "consolidation/output-formatters": "^4.1.1",
-        "psr/log": "^1|^2|^3",
-        "symfony/console": "^4.4.8|^5|^6",
-        "symfony/event-dispatcher": "^4.4.8|^5|^6",
-        "symfony/finder": "^4.4.8|^5|^6"
+        "consolidation/output-formatters": "^4.3.1",
+        "psr/log": "^1 || ^2 || ^3",
+        "symfony/console": "^4.4.8 || ^5 || ^6",
+        "symfony/event-dispatcher": "^4.4.8 || ^5 || ^6",
+        "symfony/finder": "^4.4.8 || ^5 || ^6"
     },
     "require-dev": {
         "composer-runtime-api": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "252fb6f79f3d4672b1aed9ccf6dfa4f1",
+    "content-hash": "7635dbcf5b08f582c810ef3c9f6a30c2",
     "packages": [
         {
             "name": "consolidation/output-formatters",
-            "version": "4.2.4",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "b377db7e9435c50c4e019c26ec164b547e754ca0"
+                "reference": "f65524e9ecd2bd0021c4b18710005caaa6dcbd86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/b377db7e9435c50c4e019c26ec164b547e754ca0",
-                "reference": "b377db7e9435c50c4e019c26ec164b547e754ca0",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/f65524e9ecd2bd0021c4b18710005caaa6dcbd86",
+                "reference": "f65524e9ecd2bd0021c4b18710005caaa6dcbd86",
                 "shasum": ""
             },
             "require": {
@@ -56,9 +56,9 @@
             "description": "Format text by applying transformations provided by plug-in formatters.",
             "support": {
                 "issues": "https://github.com/consolidation/output-formatters/issues",
-                "source": "https://github.com/consolidation/output-formatters/tree/4.2.4"
+                "source": "https://github.com/consolidation/output-formatters/tree/4.3.1"
             },
-            "time": "2023-02-24T03:39:10+00:00"
+            "time": "2023-05-20T03:23:06+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -290,16 +290,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.2.7",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cbad09eb8925b6ad4fb721c7a179344dc4a19d45"
+                "reference": "12288d9f4500f84a4d02254d4aa968b15488476f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cbad09eb8925b6ad4fb721c7a179344dc4a19d45",
-                "reference": "cbad09eb8925b6ad4fb721c7a179344dc4a19d45",
+                "url": "https://api.github.com/repos/symfony/console/zipball/12288d9f4500f84a4d02254d4aa968b15488476f",
+                "reference": "12288d9f4500f84a4d02254d4aa968b15488476f",
                 "shasum": ""
             },
             "require": {
@@ -361,12 +361,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.2.7"
+                "source": "https://github.com/symfony/console/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -382,7 +382,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-25T17:00:03+00:00"
+            "time": "2023-04-28T13:37:43+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -453,16 +453,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.2.7",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "404b307de426c1c488e5afad64403e5f145e82a5"
+                "reference": "04046f35fd7d72f9646e721fc2ecb8f9c67d3339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/404b307de426c1c488e5afad64403e5f145e82a5",
-                "reference": "404b307de426c1c488e5afad64403e5f145e82a5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/04046f35fd7d72f9646e721fc2ecb8f9c67d3339",
+                "reference": "04046f35fd7d72f9646e721fc2ecb8f9c67d3339",
                 "shasum": ""
             },
             "require": {
@@ -516,7 +516,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.2.7"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -532,7 +532,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:44:56+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -1094,16 +1094,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.2.7",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "67b8c1eec78296b85dc1c7d9743830160218993d"
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/67b8c1eec78296b85dc1c7d9743830160218993d",
-                "reference": "67b8c1eec78296b85dc1c7d9743830160218993d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
                 "shasum": ""
             },
             "require": {
@@ -1160,7 +1160,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.2.7"
+                "source": "https://github.com/symfony/string/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -1176,7 +1176,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-24T10:42:00+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         }
     ],
     "packages-dev": [
@@ -1311,16 +1311,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -1361,9 +1361,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1796,16 +1796,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.5",
+            "version": "9.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5"
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/86e761949019ae83f49240b2f2123fb5ab3b2fc5",
-                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
                 "shasum": ""
             },
             "require": {
@@ -1878,7 +1878,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.5"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
             },
             "funding": [
                 {
@@ -1894,7 +1895,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-09T06:34:10+00:00"
+            "time": "2023-05-11T05:14:45+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2196,16 +2197,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -2250,7 +2251,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2258,7 +2259,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
 
 /**
  * AnnotatedCommands are created automatically by the
@@ -428,6 +429,9 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
             $output,
             $this->parameterMap
         );
+
+        $formatterOptions = new FormatterOptions($commandData->annotationData()->getArrayCopy(), $commandData->input()->getOptions());
+        $commandData->setFormatterOptions($formatterOptions);
 
         // Fetch any classes (e.g. InputInterface / OutputInterface) that
         // this command's callback wants passed as a parameter and inject

--- a/src/ParameterInjection.php
+++ b/src/ParameterInjection.php
@@ -13,6 +13,8 @@ class ParameterInjection implements ParameterInjector
     {
         $this->register('Symfony\Component\Console\Input\InputInterface', $this);
         $this->register('Symfony\Component\Console\Output\OutputInterface', $this);
+        $this->register('Consolidation\AnnotatedCommand\AnnotationData', $this);
+        $this->register('Consolidation\OutputFormatters\Options\FormatterOptions', $this);
     }
 
     public function register($interfaceName, ParameterInjector $injector)
@@ -52,6 +54,10 @@ class ParameterInjection implements ParameterInjector
                 return $commandData->input();
             case 'Symfony\Component\Console\Output\OutputInterface':
                 return $commandData->output();
+            case 'Consolidation\AnnotatedCommand\AnnotationData':
+                return $commandData->annotationData();
+            case 'Consolidation\OutputFormatters\Options\FormatterOptions':
+                return $commandData->formatterOptions();
         }
 
         return null;

--- a/tests/FullStackTest.php
+++ b/tests/FullStackTest.php
@@ -146,6 +146,16 @@ class FullStackTest extends TestCase
         $this->assertRunCommandViaApplicationEquals('example:message', 'Shipwrecked; send bananas.');
         $this->assertRunCommandViaApplicationEquals('command:with-one-optional-argument', 'Hello, world');
         $this->assertRunCommandViaApplicationEquals('command:with-one-optional-argument Joe', 'Hello, Joe');
+        $this->assertRunCommandViaApplicationEquals('command:with-annotation-data', 'Annotation parameter is dynamic');
+
+        $this->assertRunCommandViaApplicationContains('command:with-format-options --format=json', 'The selected fields are first,second,third,fourth!');
+        $this->assertRunCommandViaApplicationContains('command:with-format-options --fields=I,II', 'The selected fields are I,II');
+        $this->assertRunCommandViaApplicationContains('command:with-format-options', 'The selected fields are first,third!');
+
+        $this->assertRunCommandViaApplicationContains('command:with-format-options --format=json', 'The slow value was computed');
+        $this->assertRunCommandViaApplicationContains('command:with-format-options --fields=I,III', 'The slow value was not computed');
+        $this->assertRunCommandViaApplicationContains('command:with-format-options --fields=I,II,III', 'The slow value was computed');
+        $this->assertRunCommandViaApplicationContains('command:with-format-options', 'The slow value was not computed');
 
         // Add some hooks.
         $factory->hookManager()->addValidator(new ExampleValidator());

--- a/tests/src/alpha/AlphaCommandFile.php
+++ b/tests/src/alpha/AlphaCommandFile.php
@@ -11,6 +11,7 @@ use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareTrait;
 use Symfony\Component\Console\Command\Command;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
 
 use Consolidation\TestUtils\ExampleCommandFile as ExampleAliasedClass;
 
@@ -300,6 +301,47 @@ class AlphaCommandFile implements CustomEventAwareInterface
         if (!$opts['silent']) {
             return "Hello, $who";
         }
+    }
+
+    /**
+     * @command command:with-annotation-data
+     *
+     * @custom dynamic
+     */
+    public function commandWithAnnotationData(AnnotationData $annotationData)
+    {
+        return "Annotation parameter is {$annotationData->get('custom')}";
+    }
+
+    /**
+     * Test command with formatters
+     *
+     * @command command:with-format-options
+     * @field-labels
+     *   first: I
+     *   second: II
+     *   third: III
+     *   fourth: IV
+     * @default-table-fields first,third
+     * @default-fields first,second,third,fourth
+     * @return \Consolidation\OutputFormatters\StructuredData\AssociativeList
+     */
+    public function commandWithFormatOptions(FormatterOptions $formatterOptions, $options = ['format' => 'table', 'fields' => ''])
+    {
+        $calculatedValue = '';
+        $reportedAction = 'The slow value was not computed';
+        if ($formatterOptions->fieldsContain('second')) {
+            $calculatedValue = 'A value that is slow to compute';
+            $reportedAction = 'The slow value was computed';
+        }
+
+        $outputData = [
+            'first' => "The selected fields are {$formatterOptions->fields()}!",
+            'second' => $calculatedValue,
+            'third' => $reportedAction,
+            'fourth' => 'Four',
+        ];
+        return CommandResult::data(new AssociativeList($outputData));
     }
 
     /**


### PR DESCRIPTION
Make annotation data and formatter options available to command methods that request them.

### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [x] Has tests that cover changes

### Summary
The command's AnnotationData and FormatterOptions will now be passed as a parameter to command methods that declare them.
