### PR TITLE
Silently ignore failures when preflighting option overrides.

### DIFF
--- a/src/CommandProcessor.php
+++ b/src/CommandProcessor.php
@@ -246,8 +246,11 @@ class CommandProcessor implements LoggerAwareInterface
         $format = $formatterOptions->getFormat();
         if ($format) {
             $placeholderStructuredOutput = [];
-            $formatter = $this->formatterManager->getFormatter($format);
-            $options = $this->formatterManager->overrideOptions($formatter, $placeholderStructuredOutput, $formatterOptions);
+            try {
+                $formatter = $this->formatterManager->getFormatter($format);
+                $this->formatterManager->overrideOptions($formatter, $placeholderStructuredOutput, $formatterOptions);
+            } catch (\Exception $e) {
+            }
         }
     }
 


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Preflighting the option overrides broke Drush custom help methods.