### PR TITLE
Fix #304: use native Symfony Negatable input options.

### DIFF
--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -551,24 +551,9 @@ class CommandInfo
         return $this->inputOptions;
     }
 
-    protected function addImplicitNoOptions()
-    {
-        $opts = $this->options()->getValues();
-        foreach ($opts as $name => $defaultValue) {
-            if ($defaultValue === true) {
-                $key = 'no-' . $name;
-                if (!array_key_exists($key, $opts)) {
-                    $description = "Negate --$name option.";
-                    $this->options()->add($key, $description, false);
-                }
-            }
-        }
-    }
-
     protected function createInputOptions()
     {
         $explicitOptions = [];
-        $this->addImplicitNoOptions();
 
         $opts = $this->options()->getValues();
         foreach ($opts as $name => $defaultValue) {
@@ -590,7 +575,13 @@ class CommandInfo
                 $defaultValue = null;
             }
 
-            if ($defaultValue === false) {
+            if ($defaultValue === true) {
+                $explicitOptions[$fullName] = new InputOption(
+                    $fullName,
+                    $shortcut,
+                    InputOption::VALUE_NONE | InputOption::VALUE_NEGATABLE,
+                    $description);
+            } elseif ($defaultValue === false) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_NONE, $description);
             } elseif ($defaultValue === InputOption::VALUE_REQUIRED) {
                 $explicitOptions[$fullName] = new InputOption($fullName, $shortcut, InputOption::VALUE_REQUIRED, $description, null, $suggestedValues);


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [x] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary

Changes the behaviour of Input Options with a default of value of TRUE to use Symfony Console Negatable Input Options/

### Description

https://github.com/consolidation/annotated-command/issues/304