### PR TITLE
Avoid infinite loop in Parser\CommandInfo::getName

### DIFF
--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -183,7 +183,9 @@ class CommandInfo
      */
     public function getName()
     {
-        $this->parseDocBlock();
+        if (empty($this->name)) {
+            $this->parseDocBlock();
+        }
         return $this->name;
     }
 


### PR DESCRIPTION
### Disposition
This pull request:

- [ ] Fixes a bug
- [x] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Needed by https://github.com/drush-ops/drush/pull/5818

An alternative would be to make the _name_ property public.