### PR TITLE
PHP 8.4 compatibility: implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/State/StateHelper.php
+++ b/src/State/StateHelper.php
@@ -17,7 +17,7 @@ class StateHelper
      * @param OutputInterface $output
      * @return State
      */
-    public static function injectIntoCallbackObject($callback, InputInterface $input, OutputInterface $output = null)
+    public static function injectIntoCallbackObject($callback, InputInterface $input, ?OutputInterface $output = null)
     {
         return static::inject(static::recoverCallbackObject($callback), $input, $output);
     }
@@ -29,7 +29,7 @@ class StateHelper
      * @param OutputInterface $output
      * @return State
      */
-    public static function inject($target, InputInterface $input, OutputInterface $output = null)
+    public static function inject($target, InputInterface $input, ?OutputInterface $output = null)
     {
         // Do not allow injection unless the target can save its state
         if (!$target || !($target instanceof SavableState)) {


### PR DESCRIPTION
Ref https://github.com/drush-ops/drush/issues/6069

### Disposition
This pull request:

- [ ] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes
- [x] Deprecation

### Summary
Fixed all nullable type declarations found

### Description
Testing with official docker image `docker run --rm -v $(pwd):/mnt -w /mnt php:8.4.0alpha2-cli-alpine find src -type f -name '*.php' -exec php -l {} \;`

