### PR TITLE
Fix #315: default value for the escape parameter for fputcsv() is now deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         run: Add-Content -Path $ENV:GITHUB_ENV -Value "COMPOSER_CACHE_DIR=~\AppData\Local\Composer"
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Fix a PHP 8.4 deprecation (fputcsv default args).
+
 ### 4.10.1 - 13 Dec 2024
 
 - Support PHP 8.4

--- a/src/Parser/Internal/CsvUtils.php
+++ b/src/Parser/Internal/CsvUtils.php
@@ -26,7 +26,7 @@ class CsvUtils
     public static function csvEscape(array $data, $delimiter = ',')
     {
         $buffer = fopen('php://temp', 'r+');
-        fputcsv($buffer, $data, $delimiter);
+        fputcsv($buffer, $data, $delimiter, '"', "\\");
         rewind($buffer);
         $csv = fgets($buffer);
         fclose($buffer);


### PR DESCRIPTION
### Disposition

This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary

The default escape parameter of fputcsv() is deprecated since PHP 8.4 and will be removed in next major release.
See https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.standard.

### Description

Added the current default escape parameter value to the function call.
