### PR TITLE
Fix PHP 8.5 deprecation - Reflection*::setAccessible()

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -259,7 +259,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
             // Alas, Symfony provides no accessor.
             $class = new \ReflectionClass($inputOption);
             $property = $class->getProperty('suggestedValues');
-            $property->setAccessible(true);
+            (\PHP_VERSION_ID < 80100) and $property->setAccessible(true);
             $suggestedValues = $property->getValue($inputOption);
         }
         $this->addOption(

--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -1216,7 +1216,7 @@ EOT;
     function callProtected($object, $method, $args = [])
     {
         $r = new \ReflectionMethod($object, $method);
-        $r->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) and $r->setAccessible(true);
         return $r->invokeArgs($object, $args);
     }
 

--- a/tests/FullStackTest.php
+++ b/tests/FullStackTest.php
@@ -512,7 +512,7 @@ EOT;
     function callProtected($object, $method, $args = [])
     {
         $r = new \ReflectionMethod($object, $method);
-        $r->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) and $r->setAccessible(true);
         return $r->invokeArgs($object, $args);
     }
 

--- a/tests/FullyQualifiedClassCacheTest.php
+++ b/tests/FullyQualifiedClassCacheTest.php
@@ -40,7 +40,7 @@ class FullyQualifiedClassCacheTest extends TestCase
     function callProtected($object, $method, $args = [])
     {
         $r = new \ReflectionMethod($object, $method);
-        $r->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) and $r->setAccessible(true);
         return $r->invokeArgs($object, $args);
     }
 }


### PR DESCRIPTION
ref https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

related to https://github.com/drush-ops/drush/issues/6349

### Disposition
This pull request:

- [x] Fixes a bug
- [ ] Adds a feature
- [ ] Breaks backwards compatibility
- [ ] Has tests that cover changes

### Summary
Short overview of what changed.

### Description
Any additional information.
