### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         "php": ">=7.1.3",
         "consolidation/output-formatters": "^4.3.1",
         "psr/log": "^1 || ^2 || ^3",
-        "symfony/console": "^4.4.8 || ^5 || ^6 || ^7",
-        "symfony/event-dispatcher": "^4.4.8 || ^5 || ^6 || ^7",
-        "symfony/finder": "^4.4.8 || ^5 || ^6 || ^7"
+        "symfony/console": "^4.4.8 || ^5 || ^6 || ^7 || ^8",
+        "symfony/event-dispatcher": "^4.4.8 || ^5 || ^6 || ^7 || ^8",
+        "symfony/finder": "^4.4.8 || ^5 || ^6 || ^7 || ^8"
     },
     "require-dev": {
         "composer-runtime-api": "^2.0",


### PR DESCRIPTION
Widen symfony/* constraints to allow ^8.

No code changes needed -- verified against Symfony 8.0 source that all APIs used by this package (dispatch, ignoreValidationErrors, mergeApplicationDefinition, getNativeDefinition, addOption, addArgument) are unchanged.

Ref: https://github.com/drush-ops/drush/issues/6536