### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         "php": ">=7.1.3",
         "consolidation/output-formatters": "^4.3.1",
         "psr/log": "^1 || ^2 || ^3",
-        "symfony/console": "^4.4.8 || ^5 || ^6 || ^7",
-        "symfony/event-dispatcher": "^4.4.8 || ^5 || ^6 || ^7",
-        "symfony/finder": "^4.4.8 || ^5 || ^6 || ^7"
+        "symfony/console": "^4.4.8 || ^5 || ^6 || ^7 || ^8",
+        "symfony/event-dispatcher": "^4.4.8 || ^5 || ^6 || ^7 || ^8",
+        "symfony/finder": "^4.4.8 || ^5 || ^6 || ^7 || ^8"
     },
     "require-dev": {
         "composer-runtime-api": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10cf436dde9b0d51719c72995572903a",
+    "content-hash": "059c4db307c5209f8b09816dd8fec98e",
     "packages": [
         {
             "name": "consolidation/output-formatters",

--- a/src/Hooks/HookManager.php
+++ b/src/Hooks/HookManager.php
@@ -427,7 +427,7 @@ class HookManager implements EventSubscriberInterface
     /**
      * @{@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [ConsoleEvents::COMMAND => 'callCommandEventHooks'];
     }

--- a/src/Options/AlterOptionsCommandEvent.php
+++ b/src/Options/AlterOptionsCommandEvent.php
@@ -85,7 +85,7 @@ class AlterOptionsCommandEvent implements EventSubscriberInterface
     /**
      * @{@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [ConsoleEvents::COMMAND => 'alterCommandOptions'];
     }


### PR DESCRIPTION
Widen symfony/* constraints to allow ^8.

No code changes needed — verified against Symfony 8.0 source that all APIs used
by this package (dispatch, ignoreValidationErrors, mergeApplicationDefinition,
getNativeDefinition, addOption, addArgument) are unchanged.

Ref: https://github.com/drush-ops/drush/issues/6536