### PR TITLE
Add Symfony major version matrix to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install roave/backward-compatibility-check
         run: |
           mkdir -p tools
-          composer --working-dir=tools require roave/backward-compatibility-check:^7
+          composer --working-dir=tools require roave/backward-compatibility-check:^8
 
       - name: Run roave/backward-compatibility-check
         run: ./tools/vendor/bin/roave-backward-compatibility-check --from=4.5.5 || true
@@ -151,6 +151,10 @@ jobs:
 
       - name: Clear platform php configuration in case we need to update phpunit
         run: composer config --unset platform.php
+
+      - name: Pre-install lowest dependencies before updating Symfony to the desired version
+        if: matrix.dependencies == 'lowest'
+        run: composer update --no-ansi --no-interaction --no-progress --prefer-lowest
 
       - name: Require Symfony ${{ matrix.symfony }}
         if: matrix.symfony != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
             php-version: "7.4"
             php-ini-values: assert.exception=1, zend.assertions=1
             dependencies: lowest
-            symfony: "6"
+            symfony: "5"
 
           - os: ubuntu-latest
             php-version: "8.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.5
           coverage: none
 
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.5
           coverage: none
           extensions: intl
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
 
         php-version:
           - "8.5"
@@ -117,6 +116,13 @@ jobs:
             codecov: false
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "7"
+
+          - os: windows-latest
+            php-version: "8.5"
+            dependencies: highest
+            codecov: false
+            php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
+            symfony: "8"
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Require Symfony ${{ matrix.symfony }}
         if: matrix.symfony != ''
-        run: composer require --no-interaction --no-progress symfony/console:^${{ matrix.symfony }} symfony/event-dispatcher:^${{ matrix.symfony }} symfony/finder:^${{ matrix.symfony }}
+        run: composer require --no-interaction --no-progress --with-all-dependencies symfony/console:^${{ matrix.symfony }} symfony/event-dispatcher:^${{ matrix.symfony }} symfony/finder:^${{ matrix.symfony }}
 
       - name: Run tests with phpunit
         run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,6 @@ jobs:
         php-ini-values:
           - assert.exception=1, zend.assertions=1
 
-        dependencies:
-          - locked
-
         codecov:
           - false
 
@@ -100,26 +97,22 @@ jobs:
         include:
           - os: ubuntu-latest
             php-version: "7.4"
-            dependencies: highest
             symfony: "6"
 
           - os: ubuntu-latest
             php-version: "8.1"
-            dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "6"
 
           - os: ubuntu-latest
             php-version: "8.4"
-            dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "7"
 
           - os: ubuntu-latest
             php-version: "8.5"
-            dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "8"
@@ -148,29 +141,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
-          key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+          key: php${{ matrix.php-version }}-composer-${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
+            php${{ matrix.php-version }}-composer-${{ matrix.symfony }}-
 
       - name: Make sure composer.json is valid before we start modifyig it
         run: composer validate
 
       - name: Clear platform php configuration in case we need to update phpunit
         run: composer config --unset platform.php
-
-      - name: Update phpunit if dependencies are locked in case phpunit version in lock file is not compatible
-        if: matrix.dependencies == 'locked'
-        run: |
-          composer install --no-ansi --no-interaction --no-progress
-          composer update --no-ansi --no-interaction --no-progress phpunit/phpunit --with-all-dependencies
-
-      - name: Install lowest dependencies with composer
-        if: matrix.dependencies == 'lowest'
-        run: composer update --no-ansi --no-interaction --no-progress --prefer-lowest
-
-      - name: Install highest dependencies with composer
-        if: matrix.dependencies == 'highest'
-        run: composer update --no-ansi --no-interaction --no-progress
 
       - name: Require Symfony ${{ matrix.symfony }}
         if: matrix.symfony != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,44 +99,29 @@ jobs:
 
         include:
           - os: ubuntu-latest
-            php-version: "7.1"
-            dependencies: lowest
-
-          - os: ubuntu-latest
             php-version: "7.4"
             dependencies: highest
+            symfony: "6"
 
           - os: ubuntu-latest
             php-version: "8.1"
             dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
+            symfony: "6"
 
           - os: ubuntu-latest
             php-version: "8.4"
             dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
+            symfony: "7"
 
           - os: ubuntu-latest
             php-version: "8.5"
             dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
-
-          - os: ubuntu-latest
-            php-version: "8.1"
-            dependencies: highest
-            symfony: "6"
-
-          - os: ubuntu-latest
-            php-version: "8.2"
-            dependencies: highest
-            symfony: "7"
-
-          - os: ubuntu-latest
-            php-version: "8.5"
-            dependencies: highest
             symfony: "8"
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,17 +125,17 @@ jobs:
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
 
           - os: ubuntu-latest
-            php-version: "8.2"
+            php-version: "7.1"
             dependencies: highest
             symfony: "4"
 
           - os: ubuntu-latest
-            php-version: "8.2"
+            php-version: "7.2"
             dependencies: highest
             symfony: "5"
 
           - os: ubuntu-latest
-            php-version: "8.2"
+            php-version: "8.1"
             dependencies: highest
             symfony: "6"
 
@@ -145,7 +145,7 @@ jobs:
             symfony: "7"
 
           - os: ubuntu-latest
-            php-version: "8.2"
+            php-version: "8.5"
             dependencies: highest
             symfony: "8"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,12 @@ jobs:
         include:
           - os: ubuntu-latest
             php-version: "7.4"
-            dependencies: highest
+            dependencies: lowest
             symfony: "6"
 
           - os: ubuntu-latest
             php-version: "8.1"
-            dependencies: highest
+            dependencies: lowest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "6"
@@ -158,11 +158,9 @@ jobs:
       - name: Clear platform php configuration in case we need to update phpunit
         run: composer config --unset platform.php
 
-      - name: Update phpunit if dependencies are locked in case phpunit version in lock file is not compatible
-        if: matrix.dependencies == 'locked'
-        run: |
-          composer install --no-ansi --no-interaction --no-progress
-          composer update --no-ansi --no-interaction --no-progress phpunit/phpunit --with-all-dependencies
+      - name: Require Symfony ${{ matrix.symfony }}
+        if: matrix.symfony != ''
+        run: composer require --no-interaction --no-progress --with-all-dependencies --no-install symfony/console:^${{ matrix.symfony }} symfony/event-dispatcher:^${{ matrix.symfony }} symfony/finder:^${{ matrix.symfony }}
 
       - name: Install lowest dependencies with composer
         if: matrix.dependencies == 'lowest'
@@ -171,10 +169,6 @@ jobs:
       - name: Install highest dependencies with composer
         if: matrix.dependencies == 'highest'
         run: composer update --no-ansi --no-interaction --no-progress
-
-      - name: Require Symfony ${{ matrix.symfony }}
-        if: matrix.symfony != ''
-        run: composer require --no-interaction --no-progress --with-all-dependencies symfony/console:^${{ matrix.symfony }} symfony/event-dispatcher:^${{ matrix.symfony }} symfony/finder:^${{ matrix.symfony }}
 
       - name: Run tests with phpunit
         run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: ./tools/vendor/bin/roave-backward-compatibility-check --from=4.5.5 || true
 
   tests:
-    name: Tests
+    name: Tests ${{ matrix.symfony && format('(Symfony {0})', matrix.symfony) || '' }}
 
     runs-on: ${{ matrix.os }}
 
@@ -93,6 +93,9 @@ jobs:
 
         codecov:
           - false
+
+        symfony:
+          - ""
 
         include:
           - os: ubuntu-latest
@@ -120,6 +123,31 @@ jobs:
             dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "4"
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "5"
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "6"
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "7"
+
+          - os: ubuntu-latest
+            php-version: "8.2"
+            dependencies: highest
+            symfony: "8"
 
     steps:
       - name: Checkout
@@ -168,6 +196,10 @@ jobs:
       - name: Install highest dependencies with composer
         if: matrix.dependencies == 'highest'
         run: composer update --no-ansi --no-interaction --no-progress
+
+      - name: Require Symfony ${{ matrix.symfony }}
+        if: matrix.symfony != ''
+        run: composer require --no-interaction --no-progress symfony/console:^${{ matrix.symfony }} symfony/event-dispatcher:^${{ matrix.symfony }} symfony/finder:^${{ matrix.symfony }}
 
       - name: Run tests with phpunit
         run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
         php-ini-values:
           - assert.exception=1, zend.assertions=1
 
+        dependencies:
+          - locked
+
         codecov:
           - false
 
@@ -97,22 +100,26 @@ jobs:
         include:
           - os: ubuntu-latest
             php-version: "7.4"
+            dependencies: highest
             symfony: "6"
 
           - os: ubuntu-latest
             php-version: "8.1"
+            dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "6"
 
           - os: ubuntu-latest
             php-version: "8.4"
+            dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "7"
 
           - os: ubuntu-latest
             php-version: "8.5"
+            dependencies: highest
             codecov: true
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "8"
@@ -141,15 +148,29 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
-          key: php${{ matrix.php-version }}-composer-${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}
+          key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            php${{ matrix.php-version }}-composer-${{ matrix.symfony }}-
+            php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
 
       - name: Make sure composer.json is valid before we start modifyig it
         run: composer validate
 
       - name: Clear platform php configuration in case we need to update phpunit
         run: composer config --unset platform.php
+
+      - name: Update phpunit if dependencies are locked in case phpunit version in lock file is not compatible
+        if: matrix.dependencies == 'locked'
+        run: |
+          composer install --no-ansi --no-interaction --no-progress
+          composer update --no-ansi --no-interaction --no-progress phpunit/phpunit --with-all-dependencies
+
+      - name: Install lowest dependencies with composer
+        if: matrix.dependencies == 'lowest'
+        run: composer update --no-ansi --no-interaction --no-progress --prefer-lowest
+
+      - name: Install highest dependencies with composer
+        if: matrix.dependencies == 'highest'
+        run: composer update --no-ansi --no-interaction --no-progress
 
       - name: Require Symfony ${{ matrix.symfony }}
         if: matrix.symfony != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,16 +125,6 @@ jobs:
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
 
           - os: ubuntu-latest
-            php-version: "7.1"
-            dependencies: highest
-            symfony: "4"
-
-          - os: ubuntu-latest
-            php-version: "7.2"
-            dependencies: highest
-            symfony: "5"
-
-          - os: ubuntu-latest
             php-version: "8.1"
             dependencies: highest
             symfony: "6"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,23 +83,24 @@ jobs:
           - windows-latest
 
         php-version:
-          - "8.2"
+          - "8.5"
 
         php-ini-values:
-          - assert.exception=1, zend.assertions=1
+          - assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
 
         dependencies:
-          - locked
+          - highest
 
         codecov:
           - false
 
         symfony:
-          - ""
+          - "8"
 
         include:
           - os: ubuntu-latest
             php-version: "7.4"
+            php-ini-values: assert.exception=1, zend.assertions=1
             dependencies: lowest
             symfony: "6"
 
@@ -113,16 +114,9 @@ jobs:
           - os: ubuntu-latest
             php-version: "8.4"
             dependencies: highest
-            codecov: true
+            codecov: false
             php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
             symfony: "7"
-
-          - os: ubuntu-latest
-            php-version: "8.5"
-            dependencies: highest
-            codecov: true
-            php-ini-values: assert.exception=1, zend.assertions=1, opcache.enable=1, opcache.enable_cli=1, opcache.optimization_level=-1, opcache.jit_buffer_size=4096M, opcache.jit=1205
-            symfony: "8"
 
     steps:
       - name: Checkout

--- a/ac.php
+++ b/ac.php
@@ -14,6 +14,6 @@ $commandFactory->commandProcessor()->setFormatterManager(new \Consolidation\Outp
 $commandList = $commandFactory->createCommandsFromClass($myCommandClassInstance);
 $application = new \Symfony\Component\Console\Application('ac');
 foreach ($commandList as $command) {
-    $application->add($command);
+    method_exists($application, 'addCommand') ? $application->addCommand($command) : $application->add($command);
 }
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,7 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true,
-        "platform": {
-            "php": "8.2.17"
-        }
+        "sort-packages": true
     },
     "scripts": {
         "cs": "phpcs --standard=PSR2 -n src",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "059c4db307c5209f8b09816dd8fec98e",
+    "content-hash": "08c3d049c8713eb6334f07e2043b34a4",
     "packages": [
         {
             "name": "consolidation/output-formatters",
@@ -290,47 +290,39 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.7",
+            "version": "v8.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
+                "reference": "15ed9008a4ebe2d6a78e4937f74e0c13ef2e618a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/15ed9008a4ebe2d6a78e4937f74e0c13ef2e618a",
+                "reference": "15ed9008a4ebe2d6a78e4937f74e0c13ef2e618a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -364,7 +356,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.7"
+                "source": "https://github.com/symfony/console/tree/v8.0.7"
             },
             "funding": [
                 {
@@ -384,7 +376,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T14:06:20+00:00"
+            "time": "2026-03-06T14:06:22+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -455,24 +447,24 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.4",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746"
+                "reference": "99301401da182b6cfaa4700dbe9987bb75474b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/dc2c0eba1af673e736bb851d747d266108aea746",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/99301401da182b6cfaa4700dbe9987bb75474b47",
+                "reference": "99301401da182b6cfaa4700dbe9987bb75474b47",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
+                "symfony/security-http": "<7.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -481,14 +473,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -516,7 +508,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.4"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -536,7 +528,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T11:45:34+00:00"
+            "time": "2026-01-05T11:45:55+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -616,23 +608,23 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.6",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf"
+                "reference": "441404f09a54de6d1bd6ad219e088cdf4c91f97c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/441404f09a54de6d1bd6ad219e088cdf4c91f97c",
+                "reference": "441404f09a54de6d1bd6ad219e088cdf4c91f97c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0|^8.0"
+                "symfony/filesystem": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -660,7 +652,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.6"
+                "source": "https://github.com/symfony/finder/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -680,7 +672,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T09:40:50+00:00"
+            "time": "2026-01-29T09:41:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1106,35 +1098,34 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.6",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "9f209231affa85aa930a5e46e6eb03381424b30b"
+                "reference": "6c9e1108041b5dce21a9a4984b531c4923aa9ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/9f209231affa85aa930a5e46e6eb03381424b30b",
-                "reference": "9f209231affa85aa930a5e46e6eb03381424b30b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/6c9e1108041b5dce21a9a4984b531c4923aa9ec4",
+                "reference": "6c9e1108041b5dce21a9a4984b531c4923aa9ec4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1173,7 +1164,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.6"
+                "source": "https://github.com/symfony/string/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -1193,36 +1184,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-02-09T10:14:57+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.4"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^14",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
             },
             "type": "library",
             "autoload": {
@@ -1249,7 +1239,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
             },
             "funding": [
                 {
@@ -1265,7 +1255,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2026-01-05T06:47:08+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3147,9 +3137,6 @@
     },
     "platform-dev": {
         "composer-runtime-api": "^2.0"
-    },
-    "platform-overrides": {
-        "php": "8.2.17"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -358,7 +358,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
     /**
      * {@inheritdoc}
      */
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         $state = $this->injectIntoCommandfileInstance($input, $output);
         $this->commandProcessor()->interact(

--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -370,7 +370,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
         $state->restore();
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $state = $this->injectIntoCommandfileInstance($input, $output);
         // Allow the hook manager a chance to provide configuration values,

--- a/tests/AnnotatedCommandFactoryTest.php
+++ b/tests/AnnotatedCommandFactoryTest.php
@@ -1261,7 +1261,7 @@ EOT;
         $application->setDispatcher($eventDispatcher);
 
         $application->setAutoExit(false);
-        $application->add($command);
+        method_exists($application, 'addCommand') ? $application->addCommand($command) : $application->add($command);
 
         $statusCode = $application->run($input, $output);
         $commandOutput = trim(str_replace("\r", '', $output->fetch()));

--- a/tests/AnnotatedCommandTest.php
+++ b/tests/AnnotatedCommandTest.php
@@ -32,7 +32,7 @@ class AnnotatedCommandTest extends TestCase
 
         $application = new Application('TestApplication', '0.0.0');
         $application->setAutoExit(false);
-        $application->add($command);
+        method_exists($application, 'addCommand') ? $application->addCommand($command) : $application->add($command);
 
         $statusCode = $application->run($input, $output);
         $commandOutput = trim($output->fetch());

--- a/tests/AttributesCommandFactoryTest.php
+++ b/tests/AttributesCommandFactoryTest.php
@@ -203,7 +203,7 @@ class AttributesCommandFactoryTest extends TestCase
         $application->setDispatcher($eventDispatcher);
 
         $application->setAutoExit(false);
-        $application->add($command);
+        method_exists($application, 'addCommand') ? $application->addCommand($command) : $application->add($command);
 
         $statusCode = $application->run($input, $output);
         $commandOutput = trim(str_replace("\r", '', $output->fetch()));

--- a/tests/FullStackTest.php
+++ b/tests/FullStackTest.php
@@ -66,7 +66,7 @@ class FullStackTest extends TestCase
         $commandInfo = $this->commandFactory->createCommandInfo($commandFileInstance, $functionName);
 
         $command = $this->commandFactory->createCommand($commandInfo, $commandFileInstance);
-        $this->application->add($command);
+        method_exists($this->application, 'addCommand') ? $this->application->addCommand($command) : $this->application->add($command);
 
         $containsList =
         [
@@ -462,7 +462,7 @@ EOT;
             $commandInstance = new $commandClass();
             $commandList = $factory->createCommandsFromClass($commandInstance);
             foreach ($commandList as $command) {
-                $this->application->add($command);
+                method_exists($this->application, 'addCommand') ? $this->application->addCommand($command) : $this->application->add($command);
             }
         }
     }

--- a/tests/HelpTest.php
+++ b/tests/HelpTest.php
@@ -55,7 +55,7 @@ class HelpTest extends TestCase
         $helpCommandfile = new HelpCommand($this->application);
         $commandList = $this->commandFactory->createCommandsFromClass($helpCommandfile);
         foreach ($commandList as $command) {
-            $this->application->add($command);
+            method_exists($this->application, 'addCommand') ? $this->application->addCommand($command) : $this->application->add($command);
         }
     }
 
@@ -68,7 +68,7 @@ class HelpTest extends TestCase
             $commandInstance = new $commandClass();
             $commandList = $factory->createCommandsFromClass($commandInstance);
             foreach ($commandList as $command) {
-                $this->application->add($command);
+                method_exists($this->application, 'addCommand') ? $this->application->addCommand($command) : $this->application->add($command);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds CI matrix entries to test each supported Symfony major version (4, 5, 6, 7, 8) independently
- Each matrix entry runs `composer require` to pin all Symfony dependencies (console, event-dispatcher, finder) to a specific major version before running tests
- Default test entries remain unchanged (run as-is without pinning)

## Test plan
- [ ] Verify each Symfony version matrix entry runs successfully
- [ ] Confirm default test entries are unaffected